### PR TITLE
Openwrt

### DIFF
--- a/sbin/fireqos.in
+++ b/sbin/fireqos.in
@@ -61,6 +61,9 @@ FIREQOS_LOCK_FILE=/var/run/fireqos.lock
 FIREQOS_LOCK_FILE_TIMEOUT=600
 FIREQOS_DIR=/var/run/fireqos
 
+# Gets set to 1 if this system cannot handle sub-second resolution
+FIREQOS_LOWRES_TIMER=0
+
 # Set it to 1 to see the tc commands generated.
 # Set it in the config file to overwrite this default.
 FIREQOS_DEBUG=0
@@ -2515,6 +2518,12 @@ htb_stats() {
 	
 	trap cleanup_stats EXIT
 	trap cleanup_stats SIGHUP
+
+	if [ `date +%N` = "%N" ]
+	then
+		warning "System has low-res time, stats may be inaccurate"
+		FIREQOS_LOWRES_TIMER=1
+	fi
 	
 	if [ -z "$2" -o ! -f "${FIREQOS_DIR}/$2.conf" ]
 	then
@@ -2655,6 +2664,10 @@ EOF
 		local d=`date +'%s.%N'`
 		local s=`echo $d | $cut_cmd -d '.' -f 1`
 		local n=`echo $d | $cut_cmd -d '.' -f 2 | $cut_cmd -b 1-3`
+		if [ ${FIREQOS_LOWRES_TIMER} -eq 1 ]
+		then
+			n=000
+		fi
 		echo "${s}${n}"
 	}
 	
@@ -2679,7 +2692,12 @@ EOF
 		local ms=$((sleepms - (secs * 1000)))
 	
 		# echo "Sleeping for ${secs}.${ms} (started ${startedms}, ended ${endedms}, diffms ${diffms})"
-		sleep "${secs}.${ms}"
+		if [ ${FIREQOS_LOWRES_TIMER} -eq 1 ]
+		then
+			sleep "${secs}"
+		else
+			sleep "${secs}.${ms}"
+		fi
 	}
 	
 	echo


### PR DESCRIPTION
Hi @ktsaou 

I just upgraded my OpenWRT and was able to get FireQOS running on it. I had two problems:
- OpenWRT does not have modprobe, even as an optional install, just insmod
- Its date command does not understand %N, nor does sleep understand decimals

So I made a couple of changes and am submitting them for your consideration.

FWIW I have documented my install process, currently here: http://test.firehol.org/installing/openwrt

Cheers
Phil
