### PR TITLE
firehol.in, on setting an DSCP value via a DSCP-class, use the right …

### DIFF
--- a/sbin/firehol.in
+++ b/sbin/firehol.in
@@ -8046,7 +8046,7 @@ rule() {
 						then
 							if [ "${2}" = "class" ]
 							then
-								action_param=("--set-dscp-class" "${2}")
+								action_param=("--set-dscp-class" "${3}")
 								shift
 							else
 								action_param=("--set-dscp" "${2}")


### PR DESCRIPTION
…parameter which actually contains the class

on using DSCP like this:

ipv4 dscp class EF FORWARD

the compiled iptables command then contains

-A FORWARD.1 -j DSCP --set-dscp-class class

which imho better should be:
 
-A FORWARD.1 -j DSCP --set-dscp-class EF

a quick-fix is the attached patch. but I'm unsure if this problem just come up by the "ipv4" prefix and all behind parameters get moved once to the right by this.

anyway, the attached patch also works for more when using

dscp class EF FORWARD dst "10.128.0.0/16"