### PR TITLE
Align code with firehol-blacklist(5) doc

### DIFF
--- a/sbin/firehol
+++ b/sbin/firehol
@@ -4766,7 +4766,7 @@ blacklist() {
 			shift
 			;;
 
-		statefull)
+		stateful|statefull)
 			mode=2
 			name="bs"
 			shift


### PR DESCRIPTION
- Fixed to behave as described in the doc: https://firehol.org/firehol-manual/firehol-blacklist/
- Keep historical bug to avoid existing configuration breakage
NOTE: this is really a blind change