### PR TITLE
Make saved firewall contents reproducible

### DIFF
--- a/sbin/firehol
+++ b/sbin/firehol
@@ -10103,6 +10103,9 @@ fixed_save() {
 	
 	${CAT_CMD} ${tmp} |\
 		${SED_CMD} \
+			-e "/#/s/ on .*/ on time removed by FireHOL/"	\
+			-e "s/^\[[0-9][0-9]*:[[0-9][0-9]*\]/[0:0]/"	\
+			-e "s/\[[0-9][0-9]*:[[0-9][0-9]*\]$/[0:0]/"	\
 			-e "s/--uid-owner !/! --uid-owner /g"	\
 			-e "s/--gid-owner !/! --gid-owner /g"
 	err=$?


### PR DESCRIPTION
Clean up iptables-save output to eliminate things that change per-run:
- Remove timestamp from comments
- Always write out counters as 0