### PR TITLE
Include user policies in chains before handling orphans

### DIFF
--- a/sbin/firehol
+++ b/sbin/firehol
@@ -11961,6 +11961,7 @@ firewall_filtering_policy_common() {
 		${iptables_cmd} -t filter -A INPUT -m conntrack --ctstate ESTABLISHED -j ACCEPT
 		${iptables_cmd} -t filter -A OUTPUT -m conntrack --ctstate ESTABLISHED -j ACCEPT
 		${iptables_cmd} -t filter -A FORWARD -m conntrack --ctstate ESTABLISHED -j ACCEPT
+	fi
 	if [ ! -z ${FIREHOL_GLOBAL_RPFILTER} ]
 	then
 		${iptables_cmd} -t raw -A PREROUTING -m rpfilter ${FIREHOL_GLOBAL_RPFILTER} -j DROP
@@ -11978,12 +11979,10 @@ firewall_filtering_policy_common_late() {
 	local oldns="${FIREHOL_NS_CURR}"
 
 	if [ "${iptables_cmd}" == "iptables" ]
-    then
+	then
 		FIREHOL_NS_CURR="ipv4"
 	else
 		FIREHOL_NS_CURR="ipv6"
-	fi
-
 	fi
 
 	# RELATED should not be needed

--- a/sbin/firehol
+++ b/sbin/firehol
@@ -9793,7 +9793,7 @@ create_chain() {
 
 ALL_SHOULD_ALSO_RUN_WARNING=0
 smart_function() {
-	local type="${1}" services=(${2//,/ }) service= servname= suffix= mychain= ret= fn= dogroup=0 reverse=
+	local type="${1}" services=(${2//,/ }) service= servname= suffix= mychain= ret= fn= dogroup=0 reverse= added=0
 	# type = the current subcommand: server/client/route
 	# services = the services to implement
 	shift 2
@@ -9862,7 +9862,7 @@ smart_function() {
 		ret=$?
 		
 		# simple service completed succesfully.
-		test $ret -eq 0 && continue
+		test $ret -eq 0 && added=$((added + 1)) && continue
 		
 		# simple service exists but failed.
 		if [ $ret -ne 127 ]
@@ -9879,7 +9879,7 @@ smart_function() {
 		
 		"${fn}" "${mychain}" "${type}" "${@}" "${FIREHOL_RULESET_MODE}"
 		ret=$?
-		test $ret -eq 0 && continue
+		test $ret -eq 0 && added=$((added + 1)) && continue
 		
 		if [ $ret -eq 127 ]
 		then
@@ -9889,6 +9889,12 @@ smart_function() {
 		fi
 		return 1
 	done
+
+	if [ ${added} -eq 0 ]
+		then
+		error "No service added - probably a bad variable expansion."
+		return 1
+	fi
 
 	return 0
 }

--- a/sbin/firehol
+++ b/sbin/firehol
@@ -12008,7 +12008,7 @@ firewall_filtering_policy_common_late() {
 
 		# Silently drop orphan TCP/ACK RST packets
 		# before droping INVALID below, otherwise these will be logged as INVALID too
-		${iptables_cmd} -t filter -A ${iptables_chain} -p tcp --tcp-flags ACK,FIN ACK,FIN -m conntrack --ctstate NEW,INVALID -j DROP
+		${iptables_cmd} -t filter -A ${iptables_chain} -p tcp --tcp-flags ACK,RST ACK,RST -m conntrack --ctstate NEW,INVALID -j DROP
 
 	fi
 

--- a/sbin/firehol
+++ b/sbin/firehol
@@ -6355,7 +6355,7 @@ close_interface() {
 			;;
 			
 		accept|ACCEPT)
-		    drop_noise=0
+			drop_noise=0
 			;;
 		
 		*)	
@@ -6365,14 +6365,14 @@ close_interface() {
 	esac
 
 	if [ $drop_noise -eq 1 ]; then
-	    if running_ipv4; then
-        	firewall_filtering_policy_common_late iptables "in_${work_name}"
-        	firewall_filtering_policy_common_late iptables "out_${work_name}"
-        fi
-	    if running_ipv6; then
-        	firewall_filtering_policy_common_late ip6tables "in_${work_name}"
-        	firewall_filtering_policy_common_late ip6tables "out_${work_name}"
-        fi
+		if running_ipv4; then
+			firewall_filtering_policy_common_late iptables "in_${work_name}"
+			firewall_filtering_policy_common_late iptables "out_${work_name}"
+		fi
+		if running_ipv6; then
+			firewall_filtering_policy_common_late ip6tables "in_${work_name}"
+			firewall_filtering_policy_common_late ip6tables "out_${work_name}"
+		fi
 	fi
 	
 	set_work_function "Applying default policy of ${work_policy} on interface '${work_name}'"
@@ -6486,7 +6486,7 @@ close_master() {
 
 
 	# Insert session cleanup rules here, after user rules are processed
-    if [ ${ENABLE_IPV4} -eq 1 ]
+	if [ ${ENABLE_IPV4} -eq 1 ]
 	then
 		firewall_filtering_policy_common_late iptables INPUT
 		firewall_filtering_policy_common_late iptables OUTPUT
@@ -6494,9 +6494,9 @@ close_master() {
 	fi
 	if [ ${ENABLE_IPV6} -eq 1 ]
 	then
-    	firewall_filtering_policy_common_late ip6tables INPUT
-    	firewall_filtering_policy_common_late ip6tables OUTPUT
-    	firewall_filtering_policy_common_late ip6tables FORWARD
+		firewall_filtering_policy_common_late ip6tables INPUT
+		firewall_filtering_policy_common_late ip6tables OUTPUT
+		firewall_filtering_policy_common_late ip6tables FORWARD
 	fi
 
 	set_work_function "Accepting TCP-RESET at the end of the firewall."

--- a/sbin/firehol
+++ b/sbin/firehol
@@ -6346,6 +6346,7 @@ close_interface() {
 	# make sure we have a policy
 	test -z "${work_policy}" && work_policy="${DEFAULT_INTERFACE_POLICY}"
 	local inlog=() outlog=()
+	local drop_noise=1
 	case "${work_policy}" in
 		return|RETURN)
 			set_work_function "Nothing to be done for policy RETURN of interface '${work_name}'"
@@ -6354,6 +6355,7 @@ close_interface() {
 			;;
 			
 		accept|ACCEPT)
+		    drop_noise=0
 			;;
 		
 		*)	
@@ -6361,6 +6363,17 @@ close_interface() {
 			outlog=(loglimit "OUT-${work_name}")
 			;;
 	esac
+
+	if [ $drop_noise -eq 1 ]; then
+	    if running_ipv4; then
+        	firewall_filtering_policy_common_late iptables "in_${work_name}"
+        	firewall_filtering_policy_common_late iptables "out_${work_name}"
+        fi
+	    if running_ipv6; then
+        	firewall_filtering_policy_common_late ip6tables "in_${work_name}"
+        	firewall_filtering_policy_common_late ip6tables "out_${work_name}"
+        fi
+	fi
 	
 	set_work_function "Applying default policy of ${work_policy} on interface '${work_name}'"
 
@@ -6469,6 +6482,21 @@ close_master() {
 		ip6tables -A INPUT -m conntrack --ctstate RELATED -p icmpv6 -j ACCEPT
 		ip6tables -A OUTPUT -m conntrack --ctstate RELATED -p icmpv6 -j ACCEPT
 		ip6tables -A FORWARD -m conntrack --ctstate RELATED -p icmpv6 -j ACCEPT
+	fi
+
+
+	# Insert session cleanup rules here, after user rules are processed
+    if [ ${ENABLE_IPV4} -eq 1 ]
+	then
+		firewall_filtering_policy_common_late iptables INPUT
+		firewall_filtering_policy_common_late iptables OUTPUT
+		firewall_filtering_policy_common_late iptables FORWARD
+	fi
+	if [ ${ENABLE_IPV6} -eq 1 ]
+	then
+    	firewall_filtering_policy_common_late ip6tables INPUT
+    	firewall_filtering_policy_common_late ip6tables OUTPUT
+    	firewall_filtering_policy_common_late ip6tables FORWARD
 	fi
 
 	set_work_function "Accepting TCP-RESET at the end of the firewall."
@@ -11933,6 +11961,29 @@ firewall_filtering_policy_common() {
 		${iptables_cmd} -t filter -A INPUT -m conntrack --ctstate ESTABLISHED -j ACCEPT
 		${iptables_cmd} -t filter -A OUTPUT -m conntrack --ctstate ESTABLISHED -j ACCEPT
 		${iptables_cmd} -t filter -A FORWARD -m conntrack --ctstate ESTABLISHED -j ACCEPT
+	if [ ! -z ${FIREHOL_GLOBAL_RPFILTER} ]
+	then
+		${iptables_cmd} -t raw -A PREROUTING -m rpfilter ${FIREHOL_GLOBAL_RPFILTER} -j DROP
+	fi
+}
+
+
+# this will be run when the first iptables command get executed in pre-process mode.
+# so that its commands are prepended to the other iptables commands of the firewall
+
+firewall_filtering_policy_common_late() {
+	local iptables_cmd="${1}"
+	local iptables_chain="${2}"
+
+	local oldns="${FIREHOL_NS_CURR}"
+
+	if [ "${iptables_cmd}" == "iptables" ]
+    then
+		FIREHOL_NS_CURR="ipv4"
+	else
+		FIREHOL_NS_CURR="ipv6"
+	fi
+
 	fi
 
 	# RELATED should not be needed
@@ -11948,9 +11999,7 @@ firewall_filtering_policy_common() {
 
 		# Silently drop orphan TCP/ACK FIN packets
 		# before droping INVALID below, otherwise these will be logged as INVALID too
-		${iptables_cmd} -t filter -A INPUT -p tcp --tcp-flags ACK,FIN ACK,FIN -m conntrack --ctstate NEW,INVALID -j DROP
-		${iptables_cmd} -t filter -A OUTPUT -p tcp --tcp-flags ACK,FIN ACK,FIN -m conntrack --ctstate NEW,INVALID -j DROP
-		${iptables_cmd} -t filter -A FORWARD -p tcp --tcp-flags ACK,FIN ACK,FIN -m conntrack --ctstate NEW,INVALID -j DROP
+		${iptables_cmd} -t filter -A ${iptables_chain} -p tcp --tcp-flags ACK,FIN ACK,FIN -m conntrack --ctstate NEW,INVALID -j DROP
 	fi
 
 	if [ "${FIREHOL_DROP_ORPHAN_TCP_ACK_RST}" = "1" ]
@@ -11959,9 +12008,8 @@ firewall_filtering_policy_common() {
 
 		# Silently drop orphan TCP/ACK RST packets
 		# before droping INVALID below, otherwise these will be logged as INVALID too
-		${iptables_cmd} -t filter -A INPUT -p tcp --tcp-flags ACK,RST ACK,RST -m conntrack --ctstate NEW,INVALID -j DROP
-		${iptables_cmd} -t filter -A OUTPUT -p tcp --tcp-flags ACK,RST ACK,RST -m conntrack --ctstate NEW,INVALID -j DROP
-		${iptables_cmd} -t filter -A FORWARD -p tcp --tcp-flags ACK,RST ACK,RST -m conntrack --ctstate NEW,INVALID -j DROP
+		${iptables_cmd} -t filter -A ${iptables_chain} -p tcp --tcp-flags ACK,FIN ACK,FIN -m conntrack --ctstate NEW,INVALID -j DROP
+
 	fi
 
 	if [ "${FIREHOL_DROP_ORPHAN_TCP_ACK}" = "1" ]
@@ -11970,9 +12018,7 @@ firewall_filtering_policy_common() {
 
 		# Silently drop orphan TCP/ACK packets
 		# before droping INVALID below, otherwise these will be logged as INVALID too
-		${iptables_cmd} -t filter -A INPUT -p tcp --tcp-flags ACK ACK -m conntrack --ctstate NEW,INVALID -j DROP
-		${iptables_cmd} -t filter -A OUTPUT -p tcp --tcp-flags ACK ACK -m conntrack --ctstate NEW,INVALID -j DROP
-		${iptables_cmd} -t filter -A FORWARD -p tcp --tcp-flags ACK ACK -m conntrack --ctstate NEW,INVALID -j DROP
+		${iptables_cmd} -t filter -A ${iptables_chain} -p tcp --tcp-flags ACK ACK -m conntrack --ctstate NEW,INVALID -j DROP
 	fi
 
 	if [ "${FIREHOL_DROP_ORPHAN_TCP_RST}" = "1" ]
@@ -11981,9 +12027,7 @@ firewall_filtering_policy_common() {
 
 		# Silently drop orphan TCP/RST packets
 		# before droping INVALID below, otherwise these will be logged as INVALID too
-		${iptables_cmd} -t filter -A INPUT -p tcp --tcp-flags RST RST -m conntrack --ctstate NEW,INVALID -j DROP
-		${iptables_cmd} -t filter -A OUTPUT -p tcp --tcp-flags RST RST -m conntrack --ctstate NEW,INVALID -j DROP
-		${iptables_cmd} -t filter -A FORWARD -p tcp --tcp-flags RST RST -m conntrack --ctstate NEW,INVALID -j DROP
+		${iptables_cmd} -t filter -A ${iptables_chain} -p tcp --tcp-flags RST RST -m conntrack --ctstate NEW,INVALID -j DROP
 	fi
 
 	if [ "${iptables_cmd}" = "iptables" -a "${FIREHOL_DROP_ORPHAN_IPV4_ICMP_TYPE3}" = "1" ]
@@ -11992,9 +12036,7 @@ firewall_filtering_policy_common() {
 
 		# Silently drop orphan ICMP/TYPE3 packets
 		# before droping INVALID below, otherwise these will be logged as INVALID too
-		${iptables_cmd} -t filter -A INPUT -p icmp --icmp-type destination-unreachable -m conntrack --ctstate NEW,INVALID -j DROP
-		${iptables_cmd} -t filter -A OUTPUT -p icmp --icmp-type destination-unreachable -m conntrack --ctstate NEW,INVALID -j DROP
-		${iptables_cmd} -t filter -A FORWARD -p icmp --icmp-type destination-unreachable -m conntrack --ctstate NEW,INVALID -j DROP
+		${iptables_cmd} -t filter -A ${iptables_chain} -p icmp --icmp-type destination-unreachable -m conntrack --ctstate NEW,INVALID -j DROP
 	fi
 
 	# Drop all invalid packets.
@@ -12005,20 +12047,13 @@ firewall_filtering_policy_common() {
 
 		if [ ${FIREHOL_LOG_DROP_INVALID} -eq 1 ]
 		then
-			rule table filter chain INPUT state INVALID action DROP loglimit "BLOCKED INVALID IN"
-			rule table filter chain OUTPUT state INVALID action DROP loglimit "BLOCKED INVALID OUT"
-			rule table filter chain FORWARD state INVALID action DROP loglimit "BLOCKED INVALID PASS"
+	        rule table filter chain ${iptables_chain} state INVALID action DROP loglimit "BLOCKED INVALID"
 		else
-			${iptables_cmd} -t filter -A INPUT -m conntrack --ctstate INVALID -j DROP
-			${iptables_cmd} -t filter -A OUTPUT -m conntrack --ctstate INVALID -j DROP
-			${iptables_cmd} -t filter -A FORWARD -m conntrack --ctstate INVALID -j DROP
+			${iptables_cmd} -t filter -A ${iptables_chain} -m conntrack --ctstate INVALID -j DROP
 		fi
 	fi
 
-	if [ ! -z ${FIREHOL_GLOBAL_RPFILTER} ]
-	then
-		${iptables_cmd} -t raw -A PREROUTING -m rpfilter ${FIREHOL_GLOBAL_RPFILTER} -j DROP
-	fi
+	FIREHOL_NS_CURR="${oldns}"
 }
 
 firewall_filtering_policy() {

--- a/sbin/firehol
+++ b/sbin/firehol
@@ -6469,8 +6469,24 @@ close_master() {
 		iptables_both -t mangle -A POSTROUTING -j CONNMARK --save-mark --mask ${MARKS_SAVERESTORE_STATELESS_MASK}
 	fi
 
+	set_work_function "Apply polices to drop orphan or invalid packets on INPUT/OUTPUT"
+
+	# Insert session cleanup rules here, after user rules are processed
+	# NB that the forward chain is updated along with firewall_filtering_policy_common
+	# since they may not be applied in the policy chain
+	if [ ${ENABLE_IPV4} -eq 1 ]
+	then
+		firewall_filtering_policy_common_late iptables INPUT
+		firewall_filtering_policy_common_late iptables OUTPUT
+	fi
+	if [ ${ENABLE_IPV6} -eq 1 ]
+	then
+		firewall_filtering_policy_common_late ip6tables INPUT
+		firewall_filtering_policy_common_late ip6tables OUTPUT
+	fi
+
 	set_work_function "Matching all ICMP related packets to the ESTABLISHED connections"
-	
+
 	if [ ${ENABLE_IPV4} -eq 1 ]
 	then
 		iptables -A INPUT -m conntrack --ctstate RELATED -p icmp -j ACCEPT
@@ -6482,21 +6498,6 @@ close_master() {
 		ip6tables -A INPUT -m conntrack --ctstate RELATED -p icmpv6 -j ACCEPT
 		ip6tables -A OUTPUT -m conntrack --ctstate RELATED -p icmpv6 -j ACCEPT
 		ip6tables -A FORWARD -m conntrack --ctstate RELATED -p icmpv6 -j ACCEPT
-	fi
-
-
-	# Insert session cleanup rules here, after user rules are processed
-	if [ ${ENABLE_IPV4} -eq 1 ]
-	then
-		firewall_filtering_policy_common_late iptables INPUT
-		firewall_filtering_policy_common_late iptables OUTPUT
-		firewall_filtering_policy_common_late iptables FORWARD
-	fi
-	if [ ${ENABLE_IPV6} -eq 1 ]
-	then
-		firewall_filtering_policy_common_late ip6tables INPUT
-		firewall_filtering_policy_common_late ip6tables OUTPUT
-		firewall_filtering_policy_common_late ip6tables FORWARD
 	fi
 
 	set_work_function "Accepting TCP-RESET at the end of the firewall."
@@ -12050,7 +12051,7 @@ firewall_filtering_policy_common_late() {
 
 		if [ ${FIREHOL_LOG_DROP_INVALID} -eq 1 ]
 		then
-			rule table filter chain ${iptables_chain} state INVALID action DROP loglimit "BLOCKED INVALID"
+			rule table filter chain ${iptables_chain} state INVALID action DROP loglimit "BLOCKED INVALID ${iptables_chain}"
 		else
 			${iptables_cmd} -t filter -A ${iptables_chain} -m conntrack --ctstate INVALID -j DROP
 		fi
@@ -12066,12 +12067,14 @@ firewall_filtering_policy() {
 	then
 		FIREHOL_NS_CURR="ipv4"
 		firewall_filtering_policy_common iptables
+		firewall_filtering_policy_common_late iptables FORWARD
 	fi
 
 	if [ ${ENABLE_IPV6} -eq 1 ]
 	then
 		FIREHOL_NS_CURR="ipv6"
 		firewall_filtering_policy_common ip6tables
+		firewall_filtering_policy_common_late ip6tables FORWARD
 	fi
 
 	FIREHOL_NS_CURR="${oldns}"

--- a/sbin/firehol
+++ b/sbin/firehol
@@ -11973,6 +11973,10 @@ firewall_filtering_policy_common() {
 # so that its commands are prepended to the other iptables commands of the firewall
 
 firewall_filtering_policy_common_late() {
+	if [ ${FIREHOL_FILTERING_STARTED} -eq 0 ]
+	then
+		return
+	fi
 	local iptables_cmd="${1}"
 	local iptables_chain="${2}"
 

--- a/tests/firehol/basics/interface.aud4
+++ b/tests/firehol/basics/interface.aud4
@@ -14,13 +14,6 @@
 :out_myeth3 - [0:0]
 :out_myeth4 - [0:0]
 -A INPUT -i lo -j ACCEPT
--A INPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID IN:"
--A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -i eth0 -j in_myeth0
 -A INPUT -s 10.0.0.0/8 -i eth1 -j in_myeth1
 -A INPUT ! -s 10.0.0.0/8 -i eth2 -j in_myeth2
@@ -31,6 +24,13 @@
 -A INPUT -s 192.88.99.0/24 -i eth3 -j in_myeth3
 -A INPUT -s 192.168.0.0/16 -i eth3 -j in_myeth3
 -A INPUT -i eth4 -j in_myeth4
+-A INPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A INPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A INPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
+-A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
 -A INPUT -j DROP
@@ -39,20 +39,13 @@
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID PASS:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
 -A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
--A OUTPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUT:"
--A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -o eth0 -j out_myeth0
 -A OUTPUT -d 10.0.0.0/8 -o eth1 -j out_myeth1
 -A OUTPUT ! -d 10.0.0.0/8 -o eth2 -j out_myeth2
@@ -63,20 +56,55 @@
 -A OUTPUT -d 192.88.99.0/24 -o eth3 -j out_myeth3
 -A OUTPUT -d 192.168.0.0/16 -o eth3 -j out_myeth3
 -A OUTPUT -o eth4 -j out_myeth4
+-A OUTPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A OUTPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A OUTPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
 -A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
+-A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
+-A in_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth0:"
 -A in_myeth0 -j DROP
 -A in_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
+-A in_myeth1 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth1 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth1 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth1 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth1:"
+-A in_myeth1 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth1:"
 -A in_myeth1 -j DROP
 -A in_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
+-A in_myeth2 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth2 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth2 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth2 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth2:"
+-A in_myeth2 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth2:"
 -A in_myeth2 -j DROP
 -A in_myeth3 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
+-A in_myeth3 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth3 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth3 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth3 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth3 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth3 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth3:"
+-A in_myeth3 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth3:"
 -A in_myeth3 -j DROP
 -A in_myeth4 -s 10.0.0.0/8 -j RETURN
@@ -86,22 +114,57 @@
 -A in_myeth4 -s 192.88.99.0/24 -j RETURN
 -A in_myeth4 -s 192.168.0.0/16 -j RETURN
 -A in_myeth4 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
+-A in_myeth4 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth4 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth4 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth4 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth4 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth4 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth4:"
+-A in_myeth4 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth4:"
 -A in_myeth4 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
+-A out_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
+-A out_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth0:"
 -A out_myeth0 -j DROP
 -A out_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth1 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
+-A out_myeth1 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth1 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth1 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth1 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth1:"
+-A out_myeth1 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth1:"
 -A out_myeth1 -j DROP
 -A out_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth2 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
+-A out_myeth2 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth2 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth2 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth2 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth2:"
+-A out_myeth2 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth2:"
 -A out_myeth2 -j DROP
 -A out_myeth3 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth3 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
+-A out_myeth3 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth3 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth3 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth3 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth3 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth3 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth3:"
+-A out_myeth3 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth3:"
 -A out_myeth3 -j DROP
 -A out_myeth4 -d 10.0.0.0/8 -j RETURN
@@ -112,6 +175,13 @@
 -A out_myeth4 -d 192.168.0.0/16 -j RETURN
 -A out_myeth4 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth4 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
+-A out_myeth4 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth4 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth4 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth4 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth4 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth4 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth4:"
+-A out_myeth4 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth4:"
 -A out_myeth4 -j DROP
 COMMIT

--- a/tests/firehol/basics/interface.aud6
+++ b/tests/firehol/basics/interface.aud6
@@ -14,18 +14,18 @@
 :out_myeth3 - [0:0]
 :out_myeth4 - [0:0]
 -A INPUT -i lo -j ACCEPT
--A INPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID IN:"
--A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -i eth0 -j in_myeth0
 -A INPUT -s ::/8 -i eth1 -j in_myeth1
 -A INPUT ! -s ::/8 -i eth2 -j in_myeth2
 -A INPUT -s fc00::/7 -i eth3 -j in_myeth3
 -A INPUT -s fe80::/10 -i eth3 -j in_myeth3
 -A INPUT -i eth4 -j in_myeth4
+-A INPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A INPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
+-A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
 -A INPUT -j DROP
@@ -33,66 +33,126 @@
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID PASS:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
 -A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
--A OUTPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUT:"
--A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -o eth0 -j out_myeth0
 -A OUTPUT -d ::/8 -o eth1 -j out_myeth1
 -A OUTPUT ! -d ::/8 -o eth2 -j out_myeth2
 -A OUTPUT -d fc00::/7 -o eth3 -j out_myeth3
 -A OUTPUT -d fe80::/10 -o eth3 -j out_myeth3
 -A OUTPUT -o eth4 -j out_myeth4
+-A OUTPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A OUTPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
 -A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
+-A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
+-A in_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth0:"
 -A in_myeth0 -j DROP
 -A in_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
+-A in_myeth1 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth1 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth1 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth1:"
+-A in_myeth1 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth1:"
 -A in_myeth1 -j DROP
 -A in_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
+-A in_myeth2 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth2 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth2 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth2:"
+-A in_myeth2 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth2:"
 -A in_myeth2 -j DROP
 -A in_myeth3 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
+-A in_myeth3 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth3 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth3 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth3 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth3 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth3:"
+-A in_myeth3 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth3:"
 -A in_myeth3 -j DROP
 -A in_myeth4 -s fc00::/7 -j RETURN
 -A in_myeth4 -s fe80::/10 -j RETURN
 -A in_myeth4 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
+-A in_myeth4 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth4 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth4 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth4 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth4 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth4:"
+-A in_myeth4 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth4:"
 -A in_myeth4 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
+-A out_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
+-A out_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth0:"
 -A out_myeth0 -j DROP
 -A out_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth1 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
+-A out_myeth1 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth1 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth1 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth1:"
+-A out_myeth1 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth1:"
 -A out_myeth1 -j DROP
 -A out_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth2 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
+-A out_myeth2 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth2 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth2 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth2:"
+-A out_myeth2 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth2:"
 -A out_myeth2 -j DROP
 -A out_myeth3 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth3 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
+-A out_myeth3 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth3 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth3 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth3 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth3 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth3:"
+-A out_myeth3 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth3:"
 -A out_myeth3 -j DROP
 -A out_myeth4 -d fc00::/7 -j RETURN
 -A out_myeth4 -d fe80::/10 -j RETURN
 -A out_myeth4 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth4 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
+-A out_myeth4 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth4 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth4 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth4 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth4 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth4:"
+-A out_myeth4 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth4:"
 -A out_myeth4 -j DROP
 COMMIT

--- a/tests/firehol/basics/interface46.aud4
+++ b/tests/firehol/basics/interface46.aud4
@@ -10,16 +10,16 @@
 :out_myeth1 - [0:0]
 :out_myeth2 - [0:0]
 -A INPUT -i lo -j ACCEPT
+-A INPUT -i eth0 -j in_myeth0
+-A INPUT -s 10.0.0.0/8 -i eth1 -j in_myeth1
+-A INPUT ! -s 10.0.0.0/8 -i eth2 -j in_myeth2
 -A INPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID IN:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
--A INPUT -i eth0 -j in_myeth0
--A INPUT -s 10.0.0.0/8 -i eth1 -j in_myeth1
--A INPUT ! -s 10.0.0.0/8 -i eth2 -j in_myeth2
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
 -A INPUT -j DROP
@@ -28,46 +28,88 @@
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID PASS:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
 -A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
+-A OUTPUT -o eth0 -j out_myeth0
+-A OUTPUT -d 10.0.0.0/8 -o eth1 -j out_myeth1
+-A OUTPUT ! -d 10.0.0.0/8 -o eth2 -j out_myeth2
 -A OUTPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
--A OUTPUT -o eth0 -j out_myeth0
--A OUTPUT -d 10.0.0.0/8 -o eth1 -j out_myeth1
--A OUTPUT ! -d 10.0.0.0/8 -o eth2 -j out_myeth2
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
 -A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
+-A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
+-A in_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth0:"
 -A in_myeth0 -j DROP
 -A in_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
+-A in_myeth1 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth1 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth1 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth1 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth1:"
+-A in_myeth1 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth1:"
 -A in_myeth1 -j DROP
 -A in_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
+-A in_myeth2 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth2 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth2 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth2 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth2:"
+-A in_myeth2 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth2:"
 -A in_myeth2 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
+-A out_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
+-A out_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth0:"
 -A out_myeth0 -j DROP
 -A out_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth1 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
+-A out_myeth1 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth1 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth1 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth1 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth1:"
+-A out_myeth1 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth1:"
 -A out_myeth1 -j DROP
 -A out_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth2 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
+-A out_myeth2 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth2 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth2 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth2 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth2:"
+-A out_myeth2 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth2:"
 -A out_myeth2 -j DROP
 COMMIT

--- a/tests/firehol/basics/interface46.aud6
+++ b/tests/firehol/basics/interface46.aud6
@@ -10,15 +10,15 @@
 :out_myeth1 - [0:0]
 :out_myeth2 - [0:0]
 -A INPUT -i lo -j ACCEPT
+-A INPUT -i eth1 -j in_myeth0
+-A INPUT -s fe80::/64 -i eth1 -j in_myeth1
+-A INPUT ! -s fe80::/64 -i eth2 -j in_myeth2
 -A INPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID IN:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
--A INPUT -i eth1 -j in_myeth0
--A INPUT -s fe80::/64 -i eth1 -j in_myeth1
--A INPUT ! -s fe80::/64 -i eth2 -j in_myeth2
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
 -A INPUT -j DROP
@@ -26,45 +26,81 @@
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID PASS:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
 -A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
+-A OUTPUT -o eth1 -j out_myeth0
+-A OUTPUT -d fe80::/64 -o eth1 -j out_myeth1
+-A OUTPUT ! -d fe80::/64 -o eth2 -j out_myeth2
 -A OUTPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
--A OUTPUT -o eth1 -j out_myeth0
--A OUTPUT -d fe80::/64 -o eth1 -j out_myeth1
--A OUTPUT ! -d fe80::/64 -o eth2 -j out_myeth2
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
 -A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
+-A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
+-A in_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth0:"
 -A in_myeth0 -j DROP
 -A in_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
+-A in_myeth1 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth1 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth1 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth1:"
+-A in_myeth1 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth1:"
 -A in_myeth1 -j DROP
 -A in_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
+-A in_myeth2 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth2 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth2 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth2:"
+-A in_myeth2 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth2:"
 -A in_myeth2 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
+-A out_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
+-A out_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth0:"
 -A out_myeth0 -j DROP
 -A out_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth1 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
+-A out_myeth1 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth1 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth1 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth1:"
+-A out_myeth1 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth1:"
 -A out_myeth1 -j DROP
 -A out_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth2 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
+-A out_myeth2 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth2 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth2 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth2:"
+-A out_myeth2 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth2:"
 -A out_myeth2 -j DROP
 COMMIT

--- a/tests/firehol/basics/router.aud4
+++ b/tests/firehol/basics/router.aud4
@@ -13,7 +13,7 @@
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID IN:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
@@ -23,7 +23,7 @@
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID PASS:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -s 0.0.0.0/8 -j in_routera
 -A FORWARD -s 127.0.0.0/8 -j in_routera
@@ -55,7 +55,7 @@
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT

--- a/tests/firehol/basics/router.aud6
+++ b/tests/firehol/basics/router.aud6
@@ -12,7 +12,7 @@
 -A INPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID IN:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
@@ -21,7 +21,7 @@
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID PASS:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -s ::/8 -j in_routera
 -A FORWARD -s 100::/8 -j in_routera
@@ -70,7 +70,7 @@
 -A OUTPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT

--- a/tests/firehol/basics/router46.aud4
+++ b/tests/firehol/basics/router46.aud4
@@ -11,7 +11,7 @@
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID IN:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
@@ -21,7 +21,7 @@
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID PASS:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -s 10.0.0.0/8 ! -d 12.0.0.0/8 -j in_myrouter
 -A FORWARD ! -s 12.0.0.0/8 -d 10.0.0.0/8 -j out_myrouter
@@ -35,7 +35,7 @@
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT

--- a/tests/firehol/basics/router46.aud6
+++ b/tests/firehol/basics/router46.aud6
@@ -10,7 +10,7 @@
 -A INPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID IN:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
@@ -19,7 +19,7 @@
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID PASS:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -s fe80::/64 ! -d fe80:bbbb::/64 -j in_myrouter
 -A FORWARD ! -s fe80:bbbb::/64 -d fe80::/64 -j out_myrouter
@@ -32,7 +32,7 @@
 -A OUTPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT

--- a/tests/firehol/not-both/ipv4-disable-conf.aud6
+++ b/tests/firehol/not-both/ipv4-disable-conf.aud6
@@ -6,13 +6,13 @@
 :in_myeth0 - [0:0]
 :out_myeth0 - [0:0]
 -A INPUT -i lo -j ACCEPT
+-A INPUT -i eth0 -j in_myeth0
 -A INPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID IN:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
--A INPUT -i eth0 -j in_myeth0
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
 -A INPUT -j DROP
@@ -20,29 +20,41 @@
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID PASS:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
 -A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
+-A OUTPUT -o eth0 -j out_myeth0
 -A OUTPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
--A OUTPUT -o eth0 -j out_myeth0
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
 -A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
+-A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
+-A in_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth0:"
 -A in_myeth0 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
+-A out_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
+-A out_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth0:"
 -A out_myeth0 -j DROP
 COMMIT

--- a/tests/firehol/not-both/ipv4-disable-defaults.aud6
+++ b/tests/firehol/not-both/ipv4-disable-defaults.aud6
@@ -6,13 +6,13 @@
 :in_myeth0 - [0:0]
 :out_myeth0 - [0:0]
 -A INPUT -i lo -j ACCEPT
+-A INPUT -i eth0 -j in_myeth0
 -A INPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID IN:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
--A INPUT -i eth0 -j in_myeth0
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
 -A INPUT -j DROP
@@ -20,29 +20,41 @@
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID PASS:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
 -A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
+-A OUTPUT -o eth0 -j out_myeth0
 -A OUTPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
--A OUTPUT -o eth0 -j out_myeth0
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
 -A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
+-A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
+-A in_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth0:"
 -A in_myeth0 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
+-A out_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
+-A out_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth0:"
 -A out_myeth0 -j DROP
 COMMIT

--- a/tests/firehol/not-both/ipv6-disable-conf.aud4
+++ b/tests/firehol/not-both/ipv6-disable-conf.aud4
@@ -6,14 +6,14 @@
 :in_myeth0 - [0:0]
 :out_myeth0 - [0:0]
 -A INPUT -i lo -j ACCEPT
+-A INPUT -i eth0 -j in_myeth0
 -A INPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID IN:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
--A INPUT -i eth0 -j in_myeth0
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
 -A INPUT -j DROP
@@ -22,30 +22,44 @@
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID PASS:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
 -A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
+-A OUTPUT -o eth0 -j out_myeth0
 -A OUTPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
--A OUTPUT -o eth0 -j out_myeth0
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
 -A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
+-A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
+-A in_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth0:"
 -A in_myeth0 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
+-A out_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
+-A out_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth0:"
 -A out_myeth0 -j DROP
 COMMIT

--- a/tests/firehol/not-both/ipv6-disable-defaults.aud4
+++ b/tests/firehol/not-both/ipv6-disable-defaults.aud4
@@ -6,14 +6,14 @@
 :in_myeth0 - [0:0]
 :out_myeth0 - [0:0]
 -A INPUT -i lo -j ACCEPT
+-A INPUT -i eth0 -j in_myeth0
 -A INPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID IN:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
--A INPUT -i eth0 -j in_myeth0
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
 -A INPUT -j DROP
@@ -22,30 +22,44 @@
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID PASS:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
 -A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
+-A OUTPUT -o eth0 -j out_myeth0
 -A OUTPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
--A OUTPUT -o eth0 -j out_myeth0
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
 -A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
+-A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
+-A in_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth0:"
 -A in_myeth0 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
+-A out_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
+-A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
+-A out_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth0:"
 -A out_myeth0 -j DROP
 COMMIT


### PR DESCRIPTION
FIREHOL_DROP_ORPHAN_TCP_* options generate a number of iptables drop
rules. This means that even an 'accept' policy, let alone the more
common 'client all accept', still applies filtering to the [output of the]
interface. Since these commands are described as suppressing log noise, the
only important item is that they be included before the log invalid/reject
action.
It is relatively desirable not to disable these options, as they are possibly useful on
other interfaces/traffic flows.
Refactor firewall_filtering_policy_common to break these out into a 'late'
version, and include that in user chains that do not end accept/return, as
well as in the main INPUT/OUTPUT/FORWARD chains *after* jumps to user chains.
Notably this fixes the NFS client, at least as tested on the Debian Stretch
4.9.2-2 kernel, which was failing with packets logged against the rule:

DROP       tcp  --  any    any     anywhere             anywhere             tcp flags:ACK/ACK ctstate INVALID,NEW