### PR TITLE
Expanding Google Hangouts UDP port range by 3

### DIFF
--- a/sbin/fireqos
+++ b/sbin/fireqos
@@ -233,7 +233,7 @@ server_xdmcp_ports="udp/177"
 # FireQOS only services
 server_torrents_ports="tcp/6881:6999 udp/6881:6999"
 server_facetime_ports="udp/3478:3497 udp/16384:16387 udp/16393:16402"
-server_hangouts_ports="udp/19305:19309 tcp/19305:19309"
+server_hangouts_ports="udp/19302:19309 tcp/19305:19309"
 server_gtalk_ports="tcp/5222 tcp/5228"
 server_teamviewer_ports="tcp/5938"
 server_ping_ports="icmp/any"


### PR DESCRIPTION
Hi, very minor update - I noticed the Google Hangouts ports for UDP were missing three, so I expanded the range.  TCP is fine.  Reference is here:
https://support.google.com/a/answer/1279090
![image](https://user-images.githubusercontent.com/4398871/28150212-d0d98914-6758-11e7-99fa-42bd70d3e8ea.png)
