### PR TITLE
explicitly logs BLOCKED or UNMATCHED when dropping packets

### DIFF
--- a/sbin/firehol
+++ b/sbin/firehol
@@ -3650,8 +3650,8 @@ finalize_synproxy() {
 		rule table nat chain SYNPROXY2SERVER_OUT action ACCEPT || return 1
 
 		set_work_function -ne "Orphan SYN packet from SYNPROXY"
-		rule table filter chain SYNPROXY2SERVER_IN  action DROP loglimit "ORPHAN SYNPROXY->SERVER filter.IN" || return 1
-		rule table filter chain SYNPROXY2SERVER_OUT action DROP loglimit "ORPHAN SYNPROXY->SERVER filter.OUT" || return 1
+		rule table filter chain SYNPROXY2SERVER_IN  action DROP loglimit "BLOCKED ORPHAN SYNPROXY->SERVER filter.IN" || return 1
+		rule table filter chain SYNPROXY2SERVER_OUT action DROP loglimit "BLOCKED ORPHAN SYNPROXY->SERVER filter.OUT" || return 1
 
 		FIREHOL_NS_CURR="${oldns}"
 	done
@@ -4703,7 +4703,7 @@ mac() {
 			set_work_function "Creating the MAC-MISSMATCH chain (only once)"
 		
 			iptables -t filter -N WRONGMAC
-			rule table filter chain WRONGMAC loglimit "MAC MISSMATCH" action DROP || return 1
+			rule table filter chain WRONGMAC loglimit "BLOCKED MAC MISSMATCH" action DROP || return 1
 		
 			wrongmac_chain=1
 		fi
@@ -4715,7 +4715,7 @@ mac() {
 			set_work_function "Creating the MAC-MISSMATCH chain (only once)"
 
 			ip6tables -t filter -N WRONGMAC
-			rule table filter chain WRONGMAC loglimit "MAC MISSMATCH" action DROP || return 1
+			rule table filter chain WRONGMAC loglimit "BLOCKED MAC MISSMATCH" action DROP || return 1
 
 			wrongmac6_chain=1
 		fi
@@ -5969,7 +5969,7 @@ protection() {
 				set_work_function "Rules for enforcing connection rate per client on '${prface}' for ${work_cmd} '${work_name}'"
 				
 				rule in chain "${mychain}" hashlimit "${pre}_${work_name}_connrate" upto "${rate}" mode srcip "${@}" action return || return 1
-				rule in chain "${mychain}" loglimit "CLIENT CONNECTION RATE REACHED" action drop		|| return 1
+				rule in chain "${mychain}" loglimit "BLOCKED CLIENT CONNECTION RATE REACHED" action drop		|| return 1
 				;;
 
 			connlimit)
@@ -5979,7 +5979,7 @@ protection() {
 				set_work_function "Rules for enforcing connection limit per client on '${prface}' for ${work_cmd} '${work_name}'"
 				
 				rule in chain "${mychain}" connlimit saddr upto "${@}" action return 				|| return 1
-				rule in chain "${mychain}" loglimit "CLIENT CONNECTION LIMIT REACHED" action drop		|| return 1
+				rule in chain "${mychain}" loglimit "BLOCKED CLIENT CONNECTION LIMIT REACHED" action drop		|| return 1
 				;;
 
 			fragments)
@@ -5991,7 +5991,7 @@ protection() {
 			#
 			# 		set_work_function "Rules for protection from packet fragments on '${prface}' for ${work_cmd} '${work_name}'"
 			#
-			# 		rule in chain "${mychain}" loglimit "PACKET FRAGMENTS" action drop || frag_status=$[frag_status+1]
+			# 		rule in chain "${mychain}" loglimit "BLOCKED PACKET FRAGMENTS" action drop || frag_status=$[frag_status+1]
 			# 		pop_namespace
 			# 		if [ $frag_status -gt 0 ]
 			# 		then
@@ -6011,7 +6011,7 @@ protection() {
 				
 				set_work_function "Rules for protection from new TCP connections without the SYN flag set on '${prface}' for ${work_cmd} '${work_name}'"
 				
-				rule in chain "${mychain}" loglimit "NEW TCP w/o SYN" action drop				|| return 1
+				rule in chain "${mychain}" loglimit "BLOCKED NEW TCP w/o SYN" action drop		|| return 1
 				;;
 				
 			icmp-floods)
@@ -6030,7 +6030,7 @@ protection() {
 				burst="${2-50}"
 
 				rule in chain "${mychain}" limit "${rate}" "${burst}" action return				|| return 1
-				rule in chain "${mychain}" loglimit "ICMP FLOOD" action drop					|| return 1
+				rule in chain "${mychain}" loglimit "BLOCKED ICMP FLOOD" action drop			|| return 1
 				;;
 				
 			syn-floods)
@@ -6043,7 +6043,7 @@ protection() {
 				burst="${2-50}"
 
 				rule in chain "${mychain}" limit "${rate}" "${burst}" action return				|| return 1
-				rule in chain "${mychain}" loglimit "SYN FLOOD" action drop					|| return 1
+				rule in chain "${mychain}" loglimit "BLOCKED SYN FLOOD" action drop				|| return 1
 				;;
 				
 			all-floods)
@@ -6056,7 +6056,7 @@ protection() {
 				burst="${2-50}"
 
 				rule in chain "${mychain}" limit "${rate}" "${burst}" action return				|| return 1
-				rule in chain "${mychain}" loglimit "ALL FLOOD" action drop					|| return 1
+				rule in chain "${mychain}" loglimit "BLOCKED ALL FLOOD" action drop				|| return 1
 				;;
 				
 			malformed-xmas)
@@ -6065,7 +6065,7 @@ protection() {
 				
 				set_work_function "Rules for protection from packets with all TCP flags set on '${prface}' for ${work_cmd} '${work_name}'"
 				
-				rule in chain "${mychain}" loglimit "MALFORMED XMAS" action drop				|| return 1
+				rule in chain "${mychain}" loglimit "BLOCKED MALFORMED XMAS" action drop		|| return 1
 				;;
 				
 			malformed-null)
@@ -6074,7 +6074,7 @@ protection() {
 				
 				set_work_function "Rules for protection from packets with all TCP flags unset on '${prface}' for ${work_cmd} '${work_name}'"
 				
-				rule in chain "${mychain}" loglimit "MALFORMED NULL" action drop				|| return 1
+				rule in chain "${mychain}" loglimit "BLOCKED MALFORMED NULL" action drop		|| return 1
 				;;
 				
 			malformed-bad)
@@ -6087,7 +6087,7 @@ protection() {
 				rule in chain "${in}_${work_name}" action "${mychain}"   proto tcp custom "--tcp-flags ALL     SYN,RST,ACK,FIN,URG"	|| return 1
 				rule in chain "${in}_${work_name}" action "${mychain}"   proto tcp custom "--tcp-flags ALL     FIN,URG,PSH"		|| return 1
 				
-				rule in chain "${mychain}" loglimit "MALFORMED BAD" action drop								|| return 1
+				rule in chain "${mychain}" loglimit "BLOCKED MALFORMED BAD" action drop			|| return 1
 				;;
 				
 			*)
@@ -6457,8 +6457,8 @@ close_interface() {
 			;;
 		
 		*)	
-			inlog=(loglimit "IN-${work_name}")
-			outlog=(loglimit "OUT-${work_name}")
+			inlog=(loglimit "UNMATCHED IN-${work_name}")
+			outlog=(loglimit "UNMATCHED OUT-${work_name}")
 			;;
 	esac
 
@@ -6511,8 +6511,8 @@ close_router() {
 			;;
 		
 		*)	
-			inlog=(loglimit "PASS-${work_name}")
-			outlog=(loglimit "PASS-${work_name}")
+			inlog=(loglimit "UNMATCHED PASS-${work_name}")
+			outlog=(loglimit "UNMATCHED PASS-${work_name}")
 			;;
 	esac
 	
@@ -6609,9 +6609,9 @@ close_master() {
 	#iptables -A FORWARD -m conntrack --ctstate RELATED -j ACCEPT
 
 	set_work_function "Setting default unmatched policy (options: UNMATCHED_INPUT_POLICY UNMATCHED_OUTPUT_POLICY UNMATCHED_ROUTER_POLICY)"
-	rule chain INPUT loglimit "IN-unknown" action ${UNMATCHED_INPUT_POLICY} || return 1
-	rule chain OUTPUT loglimit "OUT-unknown" action ${UNMATCHED_OUTPUT_POLICY} || return 1
-	rule chain FORWARD loglimit "PASS-unknown" action ${UNMATCHED_ROUTER_POLICY} || return 1
+	rule chain INPUT loglimit "UNMATCHED IN-unknown" action ${UNMATCHED_INPUT_POLICY} || return 1
+	rule chain OUTPUT loglimit "UNMATCHED OUT-unknown" action ${UNMATCHED_OUTPUT_POLICY} || return 1
+	rule chain FORWARD loglimit "UNMATCHED PASS-unknown" action ${UNMATCHED_ROUTER_POLICY} || return 1
 
 	# ---------------------------------------------------------------------
 	# execute all postprocessing commands for this firewall

--- a/tests/firehol/basics/empty.aud4
+++ b/tests/firehol/basics/empty.aud4
@@ -4,15 +4,15 @@
 :FORWARD DROP [0:0]
 :OUTPUT DROP [0:0]
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 COMMIT
 #

--- a/tests/firehol/basics/empty.aud6
+++ b/tests/firehol/basics/empty.aud6
@@ -4,15 +4,15 @@
 :FORWARD DROP [0:0]
 :OUTPUT DROP [0:0]
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 COMMIT
 #

--- a/tests/firehol/basics/interface.aud4
+++ b/tests/firehol/basics/interface.aud4
@@ -32,7 +32,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -43,7 +43,7 @@
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -o eth0 -j out_myeth0
@@ -65,7 +65,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -75,7 +75,7 @@
 -A in_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
--A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth0:"
+-A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
 -A in_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth1 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -85,7 +85,7 @@
 -A in_myeth1 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth1:"
 -A in_myeth1 -m conntrack --ctstate INVALID -j DROP
--A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth1:"
+-A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth1:"
 -A in_myeth1 -j DROP
 -A in_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth2 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -95,7 +95,7 @@
 -A in_myeth2 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth2:"
 -A in_myeth2 -m conntrack --ctstate INVALID -j DROP
--A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth2:"
+-A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth2:"
 -A in_myeth2 -j DROP
 -A in_myeth3 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth3 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -105,7 +105,7 @@
 -A in_myeth3 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth3 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth3:"
 -A in_myeth3 -m conntrack --ctstate INVALID -j DROP
--A in_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth3:"
+-A in_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth3:"
 -A in_myeth3 -j DROP
 -A in_myeth4 -s 10.0.0.0/8 -j RETURN
 -A in_myeth4 -s 169.254.0.0/16 -j RETURN
@@ -121,7 +121,7 @@
 -A in_myeth4 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth4 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth4:"
 -A in_myeth4 -m conntrack --ctstate INVALID -j DROP
--A in_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth4:"
+-A in_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth4:"
 -A in_myeth4 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -132,7 +132,7 @@
 -A out_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
--A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth0:"
+-A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP
 -A out_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth1 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -143,7 +143,7 @@
 -A out_myeth1 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth1:"
 -A out_myeth1 -m conntrack --ctstate INVALID -j DROP
--A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth1:"
+-A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth1:"
 -A out_myeth1 -j DROP
 -A out_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth2 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -154,7 +154,7 @@
 -A out_myeth2 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth2:"
 -A out_myeth2 -m conntrack --ctstate INVALID -j DROP
--A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth2:"
+-A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth2:"
 -A out_myeth2 -j DROP
 -A out_myeth3 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth3 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -165,7 +165,7 @@
 -A out_myeth3 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth3 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth3:"
 -A out_myeth3 -m conntrack --ctstate INVALID -j DROP
--A out_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth3:"
+-A out_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth3:"
 -A out_myeth3 -j DROP
 -A out_myeth4 -d 10.0.0.0/8 -j RETURN
 -A out_myeth4 -d 169.254.0.0/16 -j RETURN
@@ -182,7 +182,7 @@
 -A out_myeth4 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth4 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth4:"
 -A out_myeth4 -m conntrack --ctstate INVALID -j DROP
--A out_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth4:"
+-A out_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth4:"
 -A out_myeth4 -j DROP
 COMMIT
 #

--- a/tests/firehol/basics/interface.aud6
+++ b/tests/firehol/basics/interface.aud6
@@ -27,7 +27,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -37,7 +37,7 @@
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -o eth0 -j out_myeth0
@@ -54,7 +54,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -63,7 +63,7 @@
 -A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
--A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth0:"
+-A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
 -A in_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth1 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -72,7 +72,7 @@
 -A in_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth1:"
 -A in_myeth1 -m conntrack --ctstate INVALID -j DROP
--A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth1:"
+-A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth1:"
 -A in_myeth1 -j DROP
 -A in_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth2 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -81,7 +81,7 @@
 -A in_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth2:"
 -A in_myeth2 -m conntrack --ctstate INVALID -j DROP
--A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth2:"
+-A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth2:"
 -A in_myeth2 -j DROP
 -A in_myeth3 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth3 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -90,7 +90,7 @@
 -A in_myeth3 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth3 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth3:"
 -A in_myeth3 -m conntrack --ctstate INVALID -j DROP
--A in_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth3:"
+-A in_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth3:"
 -A in_myeth3 -j DROP
 -A in_myeth4 -s fc00::/7 -j RETURN
 -A in_myeth4 -s fe80::/10 -j RETURN
@@ -101,7 +101,7 @@
 -A in_myeth4 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth4 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth4:"
 -A in_myeth4 -m conntrack --ctstate INVALID -j DROP
--A in_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth4:"
+-A in_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth4:"
 -A in_myeth4 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -111,7 +111,7 @@
 -A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
--A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth0:"
+-A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP
 -A out_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth1 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -121,7 +121,7 @@
 -A out_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth1:"
 -A out_myeth1 -m conntrack --ctstate INVALID -j DROP
--A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth1:"
+-A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth1:"
 -A out_myeth1 -j DROP
 -A out_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth2 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -131,7 +131,7 @@
 -A out_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth2:"
 -A out_myeth2 -m conntrack --ctstate INVALID -j DROP
--A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth2:"
+-A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth2:"
 -A out_myeth2 -j DROP
 -A out_myeth3 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth3 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -141,7 +141,7 @@
 -A out_myeth3 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth3 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth3:"
 -A out_myeth3 -m conntrack --ctstate INVALID -j DROP
--A out_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth3:"
+-A out_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth3:"
 -A out_myeth3 -j DROP
 -A out_myeth4 -d fc00::/7 -j RETURN
 -A out_myeth4 -d fe80::/10 -j RETURN
@@ -153,7 +153,7 @@
 -A out_myeth4 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth4 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth4:"
 -A out_myeth4 -m conntrack --ctstate INVALID -j DROP
--A out_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth4:"
+-A out_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth4:"
 -A out_myeth4 -j DROP
 COMMIT
 #

--- a/tests/firehol/basics/interface46.aud4
+++ b/tests/firehol/basics/interface46.aud4
@@ -21,7 +21,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -32,7 +32,7 @@
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -o eth0 -j out_myeth0
@@ -47,7 +47,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -57,7 +57,7 @@
 -A in_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
--A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth0:"
+-A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
 -A in_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth1 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -67,7 +67,7 @@
 -A in_myeth1 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth1:"
 -A in_myeth1 -m conntrack --ctstate INVALID -j DROP
--A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth1:"
+-A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth1:"
 -A in_myeth1 -j DROP
 -A in_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth2 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -77,7 +77,7 @@
 -A in_myeth2 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth2:"
 -A in_myeth2 -m conntrack --ctstate INVALID -j DROP
--A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth2:"
+-A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth2:"
 -A in_myeth2 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -88,7 +88,7 @@
 -A out_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
--A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth0:"
+-A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP
 -A out_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth1 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -99,7 +99,7 @@
 -A out_myeth1 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth1:"
 -A out_myeth1 -m conntrack --ctstate INVALID -j DROP
--A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth1:"
+-A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth1:"
 -A out_myeth1 -j DROP
 -A out_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth2 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -110,7 +110,7 @@
 -A out_myeth2 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth2:"
 -A out_myeth2 -m conntrack --ctstate INVALID -j DROP
--A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth2:"
+-A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth2:"
 -A out_myeth2 -j DROP
 COMMIT
 #

--- a/tests/firehol/basics/interface46.aud6
+++ b/tests/firehol/basics/interface46.aud6
@@ -20,7 +20,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -30,7 +30,7 @@
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -o eth1 -j out_myeth0
@@ -44,7 +44,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -53,7 +53,7 @@
 -A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
--A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth0:"
+-A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
 -A in_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth1 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -62,7 +62,7 @@
 -A in_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth1:"
 -A in_myeth1 -m conntrack --ctstate INVALID -j DROP
--A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth1:"
+-A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth1:"
 -A in_myeth1 -j DROP
 -A in_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth2 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -71,7 +71,7 @@
 -A in_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth2:"
 -A in_myeth2 -m conntrack --ctstate INVALID -j DROP
--A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth2:"
+-A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth2:"
 -A in_myeth2 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -81,7 +81,7 @@
 -A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
--A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth0:"
+-A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP
 -A out_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth1 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -91,7 +91,7 @@
 -A out_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth1:"
 -A out_myeth1 -m conntrack --ctstate INVALID -j DROP
--A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth1:"
+-A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth1:"
 -A out_myeth1 -j DROP
 -A out_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth2 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -101,7 +101,7 @@
 -A out_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth2:"
 -A out_myeth2 -m conntrack --ctstate INVALID -j DROP
--A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth2:"
+-A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth2:"
 -A out_myeth2 -j DROP
 COMMIT
 #

--- a/tests/firehol/basics/router.aud4
+++ b/tests/firehol/basics/router.aud4
@@ -16,7 +16,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -47,7 +47,7 @@
 -A FORWARD -j out_routerb
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -59,7 +59,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_routera -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_routera -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT

--- a/tests/firehol/basics/router.aud6
+++ b/tests/firehol/basics/router.aud6
@@ -15,7 +15,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -63,7 +63,7 @@
 -A FORWARD -j out_routerb
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -74,7 +74,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_routera -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_routera -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT

--- a/tests/firehol/basics/router46.aud4
+++ b/tests/firehol/basics/router46.aud4
@@ -14,7 +14,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -27,7 +27,7 @@
 -A FORWARD ! -s 12.0.0.0/8 -d 10.0.0.0/8 -j out_myrouter
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -39,7 +39,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myrouter -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myrouter -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT

--- a/tests/firehol/basics/router46.aud6
+++ b/tests/firehol/basics/router46.aud6
@@ -13,7 +13,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -25,7 +25,7 @@
 -A FORWARD ! -s fe80:bbbb::/64 -d fe80::/64 -j out_myrouter
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -36,7 +36,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myrouter -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myrouter -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT

--- a/tests/firehol/not-both/ipv4-disable-conf.aud6
+++ b/tests/firehol/not-both/ipv4-disable-conf.aud6
@@ -14,7 +14,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -24,7 +24,7 @@
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -o eth0 -j out_myeth0
@@ -36,7 +36,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -45,7 +45,7 @@
 -A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
--A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth0:"
+-A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -55,7 +55,7 @@
 -A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
--A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth0:"
+-A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP
 COMMIT
 #

--- a/tests/firehol/not-both/ipv4-disable-defaults.aud6
+++ b/tests/firehol/not-both/ipv4-disable-defaults.aud6
@@ -14,7 +14,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -24,7 +24,7 @@
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -o eth0 -j out_myeth0
@@ -36,7 +36,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -45,7 +45,7 @@
 -A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
--A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth0:"
+-A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -55,7 +55,7 @@
 -A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
--A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth0:"
+-A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP
 COMMIT
 #

--- a/tests/firehol/not-both/ipv6-disable-conf.aud4
+++ b/tests/firehol/not-both/ipv6-disable-conf.aud4
@@ -15,7 +15,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -26,7 +26,7 @@
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -o eth0 -j out_myeth0
@@ -39,7 +39,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -49,7 +49,7 @@
 -A in_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
--A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth0:"
+-A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -60,7 +60,7 @@
 -A out_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
--A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth0:"
+-A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP
 COMMIT
 #

--- a/tests/firehol/not-both/ipv6-disable-defaults.aud4
+++ b/tests/firehol/not-both/ipv6-disable-defaults.aud4
@@ -15,7 +15,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -26,7 +26,7 @@
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -o eth0 -j out_myeth0
@@ -39,7 +39,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -49,7 +49,7 @@
 -A in_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
--A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "IN-myeth0:"
+-A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -60,7 +60,7 @@
 -A out_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
--A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "OUT-myeth0:"
+-A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP
 COMMIT
 #


### PR DESCRIPTION
In many cases, for auditing reasons we add log lines to verify connections have been established.

An easy way to do it, is by adding this at the top of firehol.conf:

```sh
   action AUDIT_ACCEPT \
        action ACCEPT state NEW log "AUDIT ACCEPT" \
        next action ACCEPT
```

So, we can later use `server xxx AUDIT_ACCEPT`.

In such cases, the indirectly dropped packets which are logged without any positive or negative indication, are often misinterpreted. 

This PR, adds `BLOCKED` or `UNMATCHED` to all such log lines, to make it clear that these logs have actually blocked traffic.