### PR TITLE
allow DROP_INVALID with any action (e.g. REJECT)

### DIFF
--- a/sbin/firehol
+++ b/sbin/firehol
@@ -409,6 +409,9 @@ FIREHOL_DROP_INVALID=1
 # Default: 1
 FIREHOL_LOG_DROP_INVALID=1
 
+# the action to be performed when we drop INVALID packets
+FIREHOL_DROP_INVALID_ACTION="DROP"
+
 # If set to 1, FireHOL will silently drop orphan TCP packets with ACK,FIN set.
 # In modern kernels, the connection tracker detects closed sockets
 # and removes them from memory before receiving the FIN,ACK from the remote
@@ -5640,9 +5643,9 @@ protection() {
 			invalid)
 				if [ "${FIREHOL_DROP_INVALID}" -eq 0 ]
 				then
-					set_work_function "Rules for dropping invalid packets on '${prface}' for ${work_cmd} '${work_name}'"
+					set_work_function "Rules to ${FIREHOL_DROP_INVALID_ACTION} invalid packets on '${prface}' for ${work_cmd} '${work_name}'"
 					
-					rule in chain "${in}_${work_name}" state INVALID action drop || return 1
+					rule in chain "${in}_${work_name}" state INVALID action ${FIREHOL_DROP_INVALID_ACTION} || return 1
 				fi
 				;;
 			
@@ -11838,9 +11841,9 @@ firewall_filtering_policy_common_late() {
 
 		if [ ${FIREHOL_LOG_DROP_INVALID} -eq 1 ]
 		then
-			rule table filter chain ${iptables_chain} state INVALID action DROP loglimit "BLOCKED INVALID ${iptables_chain}"
+			rule table filter chain ${iptables_chain} state INVALID action ${FIREHOL_DROP_INVALID_ACTION} loglimit "${FIREHOL_DROP_INVALID_ACTION} INVALID ${iptables_chain}"
 		else
-			${iptables_cmd} -t filter -A ${iptables_chain} -m conntrack --ctstate INVALID -j DROP
+			rule table filter chain ${iptables_chain} state INVALID action ${FIREHOL_DROP_INVALID_ACTION}
 		fi
 	fi
 

--- a/tests/firehol/basics/interface.aud4
+++ b/tests/firehol/basics/interface.aud4
@@ -29,7 +29,7 @@
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
@@ -39,7 +39,7 @@
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -61,7 +61,7 @@
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -73,7 +73,7 @@
 -A in_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
+-A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
@@ -83,7 +83,7 @@
 -A in_myeth1 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth1 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A in_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth1:"
+-A in_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth1:"
 -A in_myeth1 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth1:"
 -A in_myeth1 -j DROP
@@ -93,7 +93,7 @@
 -A in_myeth2 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth2 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A in_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth2:"
+-A in_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth2:"
 -A in_myeth2 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth2:"
 -A in_myeth2 -j DROP
@@ -103,7 +103,7 @@
 -A in_myeth3 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth3 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth3 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A in_myeth3 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth3:"
+-A in_myeth3 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth3:"
 -A in_myeth3 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth3:"
 -A in_myeth3 -j DROP
@@ -119,7 +119,7 @@
 -A in_myeth4 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth4 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth4 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A in_myeth4 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth4:"
+-A in_myeth4 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth4:"
 -A in_myeth4 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth4:"
 -A in_myeth4 -j DROP
@@ -130,7 +130,7 @@
 -A out_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
+-A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP
@@ -141,7 +141,7 @@
 -A out_myeth1 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth1 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A out_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth1:"
+-A out_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth1:"
 -A out_myeth1 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth1:"
 -A out_myeth1 -j DROP
@@ -152,7 +152,7 @@
 -A out_myeth2 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth2 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A out_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth2:"
+-A out_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth2:"
 -A out_myeth2 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth2:"
 -A out_myeth2 -j DROP
@@ -163,7 +163,7 @@
 -A out_myeth3 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth3 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth3 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A out_myeth3 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth3:"
+-A out_myeth3 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth3:"
 -A out_myeth3 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth3:"
 -A out_myeth3 -j DROP
@@ -180,7 +180,7 @@
 -A out_myeth4 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth4 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth4 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A out_myeth4 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth4:"
+-A out_myeth4 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth4:"
 -A out_myeth4 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth4:"
 -A out_myeth4 -j DROP

--- a/tests/firehol/basics/interface.aud6
+++ b/tests/firehol/basics/interface.aud6
@@ -24,7 +24,7 @@
 -A INPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
@@ -33,7 +33,7 @@
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -50,7 +50,7 @@
 -A OUTPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -61,7 +61,7 @@
 -A in_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
+-A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
@@ -70,7 +70,7 @@
 -A in_myeth1 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth1 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A in_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth1:"
+-A in_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth1:"
 -A in_myeth1 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth1:"
 -A in_myeth1 -j DROP
@@ -79,7 +79,7 @@
 -A in_myeth2 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth2 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A in_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth2:"
+-A in_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth2:"
 -A in_myeth2 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth2:"
 -A in_myeth2 -j DROP
@@ -88,7 +88,7 @@
 -A in_myeth3 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth3 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth3 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A in_myeth3 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth3:"
+-A in_myeth3 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth3:"
 -A in_myeth3 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth3:"
 -A in_myeth3 -j DROP
@@ -99,7 +99,7 @@
 -A in_myeth4 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth4 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth4 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A in_myeth4 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth4:"
+-A in_myeth4 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth4:"
 -A in_myeth4 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth4:"
 -A in_myeth4 -j DROP
@@ -109,7 +109,7 @@
 -A out_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
+-A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP
@@ -119,7 +119,7 @@
 -A out_myeth1 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth1 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A out_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth1:"
+-A out_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth1:"
 -A out_myeth1 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth1:"
 -A out_myeth1 -j DROP
@@ -129,7 +129,7 @@
 -A out_myeth2 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth2 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A out_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth2:"
+-A out_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth2:"
 -A out_myeth2 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth2:"
 -A out_myeth2 -j DROP
@@ -139,7 +139,7 @@
 -A out_myeth3 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth3 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth3 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A out_myeth3 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth3:"
+-A out_myeth3 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth3:"
 -A out_myeth3 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth3:"
 -A out_myeth3 -j DROP
@@ -151,7 +151,7 @@
 -A out_myeth4 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth4 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth4 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A out_myeth4 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth4:"
+-A out_myeth4 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth4:"
 -A out_myeth4 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth4:"
 -A out_myeth4 -j DROP

--- a/tests/firehol/basics/interface46.aud4
+++ b/tests/firehol/basics/interface46.aud4
@@ -18,7 +18,7 @@
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
@@ -28,7 +28,7 @@
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -43,7 +43,7 @@
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -55,7 +55,7 @@
 -A in_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
+-A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
@@ -65,7 +65,7 @@
 -A in_myeth1 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth1 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A in_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth1:"
+-A in_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth1:"
 -A in_myeth1 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth1:"
 -A in_myeth1 -j DROP
@@ -75,7 +75,7 @@
 -A in_myeth2 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth2 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A in_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth2:"
+-A in_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth2:"
 -A in_myeth2 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth2:"
 -A in_myeth2 -j DROP
@@ -86,7 +86,7 @@
 -A out_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
+-A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP
@@ -97,7 +97,7 @@
 -A out_myeth1 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth1 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A out_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth1:"
+-A out_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth1:"
 -A out_myeth1 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth1:"
 -A out_myeth1 -j DROP
@@ -108,7 +108,7 @@
 -A out_myeth2 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth2 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A out_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth2:"
+-A out_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth2:"
 -A out_myeth2 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth2:"
 -A out_myeth2 -j DROP

--- a/tests/firehol/basics/interface46.aud6
+++ b/tests/firehol/basics/interface46.aud6
@@ -17,7 +17,7 @@
 -A INPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
@@ -26,7 +26,7 @@
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -40,7 +40,7 @@
 -A OUTPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -51,7 +51,7 @@
 -A in_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
+-A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
@@ -60,7 +60,7 @@
 -A in_myeth1 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth1 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A in_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth1:"
+-A in_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth1:"
 -A in_myeth1 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth1:"
 -A in_myeth1 -j DROP
@@ -69,7 +69,7 @@
 -A in_myeth2 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth2 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A in_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth2:"
+-A in_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth2:"
 -A in_myeth2 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth2:"
 -A in_myeth2 -j DROP
@@ -79,7 +79,7 @@
 -A out_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
+-A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP
@@ -89,7 +89,7 @@
 -A out_myeth1 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth1 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A out_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth1:"
+-A out_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth1:"
 -A out_myeth1 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth1:"
 -A out_myeth1 -j DROP
@@ -99,7 +99,7 @@
 -A out_myeth2 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth2 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A out_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth2:"
+-A out_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth2:"
 -A out_myeth2 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth2:"
 -A out_myeth2 -j DROP

--- a/tests/firehol/basics/router.aud4
+++ b/tests/firehol/basics/router.aud4
@@ -13,7 +13,7 @@
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
@@ -23,7 +23,7 @@
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -s 0.0.0.0/8 -j in_routera
 -A FORWARD -s 127.0.0.0/8 -j in_routera
@@ -55,7 +55,7 @@
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT

--- a/tests/firehol/basics/router.aud6
+++ b/tests/firehol/basics/router.aud6
@@ -12,7 +12,7 @@
 -A INPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
@@ -21,7 +21,7 @@
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -s ::/8 -j in_routera
 -A FORWARD -s 100::/8 -j in_routera
@@ -70,7 +70,7 @@
 -A OUTPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT

--- a/tests/firehol/basics/router46.aud4
+++ b/tests/firehol/basics/router46.aud4
@@ -11,7 +11,7 @@
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
@@ -21,7 +21,7 @@
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -s 10.0.0.0/8 ! -d 12.0.0.0/8 -j in_myrouter
 -A FORWARD ! -s 12.0.0.0/8 -d 10.0.0.0/8 -j out_myrouter
@@ -35,7 +35,7 @@
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT

--- a/tests/firehol/basics/router46.aud6
+++ b/tests/firehol/basics/router46.aud6
@@ -10,7 +10,7 @@
 -A INPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
@@ -19,7 +19,7 @@
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -s fe80::/64 ! -d fe80:bbbb::/64 -j in_myrouter
 -A FORWARD ! -s fe80:bbbb::/64 -d fe80::/64 -j out_myrouter
@@ -32,7 +32,7 @@
 -A OUTPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT

--- a/tests/firehol/not-both/ipv4-disable-conf.aud6
+++ b/tests/firehol/not-both/ipv4-disable-conf.aud6
@@ -11,7 +11,7 @@
 -A INPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
@@ -20,7 +20,7 @@
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -32,7 +32,7 @@
 -A OUTPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -43,7 +43,7 @@
 -A in_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
+-A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
@@ -53,7 +53,7 @@
 -A out_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
+-A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP

--- a/tests/firehol/not-both/ipv4-disable-defaults.aud6
+++ b/tests/firehol/not-both/ipv4-disable-defaults.aud6
@@ -11,7 +11,7 @@
 -A INPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
@@ -20,7 +20,7 @@
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -32,7 +32,7 @@
 -A OUTPUT -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -43,7 +43,7 @@
 -A in_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
+-A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
@@ -53,7 +53,7 @@
 -A out_myeth0 -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
--A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
+-A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP

--- a/tests/firehol/not-both/ipv6-disable-conf.aud4
+++ b/tests/firehol/not-both/ipv6-disable-conf.aud4
@@ -12,7 +12,7 @@
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
@@ -22,7 +22,7 @@
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -35,7 +35,7 @@
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -47,7 +47,7 @@
 -A in_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
+-A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
@@ -58,7 +58,7 @@
 -A out_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
+-A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP

--- a/tests/firehol/not-both/ipv6-disable-defaults.aud4
+++ b/tests/firehol/not-both/ipv6-disable-defaults.aud4
@@ -12,7 +12,7 @@
 -A INPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A INPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID INPUT:"
+-A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
@@ -22,7 +22,7 @@
 -A FORWARD -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID FORWARD:"
+-A FORWARD -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID FORWARD:"
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -35,7 +35,7 @@
 -A OUTPUT -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A OUTPUT -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID OUTPUT:"
+-A OUTPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID OUTPUT:"
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -47,7 +47,7 @@
 -A in_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID in_myeth0:"
+-A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
@@ -58,7 +58,7 @@
 -A out_myeth0 -p tcp -m tcp --tcp-flags ACK ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
--A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "BLOCKED INVALID out_myeth0:"
+-A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
 -A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP


### PR DESCRIPTION
This PR adds a new configuration option:

```sh
FIREHOL_DROP_INVALID_ACTION="DROP"
```

The user may change this setting to `REJECT` traffic.

This is required in long-living sockets that once removed from the connection tracker, they had to timeout. By setting this to `REJECT`, the invalid packet will be rejected, allowing the remote end to clean up faster.
