### PR TITLE
added option FIREHOL_ACCEPT_OUTPUT_UNMATCHED_TCP_RST

### DIFF
--- a/sbin/firehol
+++ b/sbin/firehol
@@ -412,6 +412,12 @@ FIREHOL_LOG_DROP_INVALID=1
 # the action to be performed when we drop INVALID packets
 FIREHOL_DROP_INVALID_ACTION="DROP"
 
+# If set to 1, FireHOL will accept unmatched outbound RST packets.
+# This is needed when the firewall is expected to reject orphan
+# routed connections.
+# Default: 0
+FIREHOL_ACCEPT_OUTPUT_UNMATCHED_TCP_RST=0
+
 # If set to 1, FireHOL will silently drop orphan TCP packets with ACK,FIN set.
 # In modern kernels, the connection tracker detects closed sockets
 # and removes them from memory before receiving the FIN,ACK from the remote
@@ -5544,13 +5550,13 @@ run_fast() {
 # produce the iptables rules.
 
 policy() {
-        work_realcmd_secondary ${FUNCNAME} "${@}"
+	work_realcmd_secondary ${FUNCNAME} "${@}"
 	
 	require_work set any || return 1
 	
 	set_work_function "Policy of ${work_name} to ${1}"
 	work_policy="$*"
-	
+
 	return 0
 }
 
@@ -5569,7 +5575,7 @@ client4() { ipv4 client "${@}"; }
 client6() { ipv6 client "${@}"; }
 client46() { both client "${@}"; }
 client() {
-        work_realcmd_secondary ${FUNCNAME} "${@}"
+	work_realcmd_secondary ${FUNCNAME} "${@}"
 	
 	require_work set any || return 1
 	smart_function client "${@}"
@@ -5580,7 +5586,7 @@ route4() { ipv4 route "${@}"; }
 route6() { ipv6 route "${@}"; }
 route46() { both route "${@}"; }
 route() {
-        work_realcmd_secondary ${FUNCNAME} "${@}"
+	work_realcmd_secondary ${FUNCNAME} "${@}"
 	
 	require_work set router || return 1
 	smart_function server "${@}"
@@ -5593,7 +5599,7 @@ route() {
 FIREHOL_PROTECTION_COUNT=0
 
 protection() {
-        work_realcmd_secondary ${FUNCNAME} "${@}"
+	work_realcmd_secondary ${FUNCNAME} "${@}"
 	
 	require_work set any || return 1
 	
@@ -6144,19 +6150,19 @@ close_interface() {
 			;;
 		
 		*)	
-			inlog=(loglimit "UNMATCHED IN-${work_name}")
-			outlog=(loglimit "UNMATCHED OUT-${work_name}")
+			inlog=(loglimit "${work_policy/ */} UNMATCHED IN-${work_name}")
+			outlog=(loglimit "${work_policy/ */} UNMATCHED OUT-${work_name}")
 			;;
 	esac
 
 	if [ $drop_noise -eq 1 ]; then
 		if running_ipv4; then
-			firewall_filtering_policy_common_late iptables "in_${work_name}"
-			firewall_filtering_policy_common_late iptables "out_${work_name}"
+			firewall_filtering_policy_common_late iptables INPUT "in_${work_name}"
+			firewall_filtering_policy_common_late iptables OUTPUT "out_${work_name}"
 		fi
 		if running_ipv6; then
-			firewall_filtering_policy_common_late ip6tables "in_${work_name}"
-			firewall_filtering_policy_common_late ip6tables "out_${work_name}"
+			firewall_filtering_policy_common_late ip6tables INPUT "in_${work_name}"
+			firewall_filtering_policy_common_late ip6tables OUTPUT "out_${work_name}"
 		fi
 	fi
 	
@@ -6198,8 +6204,8 @@ close_router() {
 			;;
 		
 		*)	
-			inlog=(loglimit "UNMATCHED PASS-${work_name}")
-			outlog=(loglimit "UNMATCHED PASS-${work_name}")
+			inlog=(loglimit "${work_policy/ */} UNMATCHED PASS-${work_name}")
+			outlog=(loglimit "${work_policy/ */} UNMATCHED PASS-${work_name}")
 			;;
 	esac
 	
@@ -6261,13 +6267,13 @@ close_master() {
 	# since they may not be applied in the policy chain
 	if [ ${ENABLE_IPV4} -eq 1 ]
 	then
-		firewall_filtering_policy_common_late iptables INPUT
-		firewall_filtering_policy_common_late iptables OUTPUT
+		firewall_filtering_policy_common_late iptables INPUT INPUT
+		firewall_filtering_policy_common_late iptables OUTPUT OUTPUT
 	fi
 	if [ ${ENABLE_IPV6} -eq 1 ]
 	then
-		firewall_filtering_policy_common_late ip6tables INPUT
-		firewall_filtering_policy_common_late ip6tables OUTPUT
+		firewall_filtering_policy_common_late ip6tables INPUT INPUT
+		firewall_filtering_policy_common_late ip6tables OUTPUT OUTPUT
 	fi
 
 	set_work_function "Matching all ICMP related packets to the ESTABLISHED connections"
@@ -6296,9 +6302,9 @@ close_master() {
 	#iptables -A FORWARD -m conntrack --ctstate RELATED -j ACCEPT
 
 	set_work_function "Setting default unmatched policy (options: UNMATCHED_INPUT_POLICY UNMATCHED_OUTPUT_POLICY UNMATCHED_ROUTER_POLICY)"
-	rule chain INPUT loglimit "UNMATCHED IN-unknown" action ${UNMATCHED_INPUT_POLICY} || return 1
-	rule chain OUTPUT loglimit "UNMATCHED OUT-unknown" action ${UNMATCHED_OUTPUT_POLICY} || return 1
-	rule chain FORWARD loglimit "UNMATCHED PASS-unknown" action ${UNMATCHED_ROUTER_POLICY} || return 1
+	rule chain INPUT loglimit "${UNMATCHED_INPUT_POLICY/ */} UNMATCHED IN-unknown" action ${UNMATCHED_INPUT_POLICY} || return 1
+	rule chain OUTPUT loglimit "${UNMATCHED_OUTPUT_POLICY/ */} UNMATCHED OUT-unknown" action ${UNMATCHED_OUTPUT_POLICY} || return 1
+	rule chain FORWARD loglimit "${UNMATCHED_ROUTER_POLICY/ */} UNMATCHED PASS-unknown" action ${UNMATCHED_ROUTER_POLICY} || return 1
 
 	# ---------------------------------------------------------------------
 	# execute all postprocessing commands for this firewall
@@ -11769,7 +11775,8 @@ firewall_filtering_policy_common_late() {
 		return
 	fi
 	local iptables_cmd="${1}"
-	local iptables_chain="${2}"
+	local main_chain="${2}"
+	local iptables_chain="${3}"
 
 	local oldns="${FIREHOL_NS_CURR}"
 
@@ -11786,6 +11793,12 @@ firewall_filtering_policy_common_late() {
 	# ${iptables_cmd} -t filter -A INPUT -m conntrack --ctstate RELATED -j ACCEPT
 	# ${iptables_cmd} -t filter -A OUTPUT -m conntrack --ctstate RELATED -j ACCEPT
 	# ${iptables_cmd} -t filter -A FORWARD -m conntrack --ctstate RELATED -j ACCEPT
+
+	if [ "${FIREHOL_ACCEPT_OUTPUT_UNMATCHED_TCP_RST}" = "1" -a "${main_chain}" = "OUTPUT" ]
+	then
+		set_work_function "Accepting TCP RST packets on OUTPUT (option: FIREHOL_ACCEPT_OUTPUT_UNMATCHED_TCP_RST)"
+		${iptables_cmd} -t filter -A ${iptables_chain} -p tcp --tcp-flags RST RST -j ACCEPT
+	fi
 
 	if [ "${FIREHOL_DROP_ORPHAN_TCP_ACK_FIN}" = "1" ]
 	then
@@ -11857,14 +11870,14 @@ firewall_filtering_policy() {
 	then
 		FIREHOL_NS_CURR="ipv4"
 		firewall_filtering_policy_common iptables
-		firewall_filtering_policy_common_late iptables FORWARD
+		firewall_filtering_policy_common_late iptables FORWARD FORWARD
 	fi
 
 	if [ ${ENABLE_IPV6} -eq 1 ]
 	then
 		FIREHOL_NS_CURR="ipv6"
 		firewall_filtering_policy_common ip6tables
-		firewall_filtering_policy_common_late ip6tables FORWARD
+		firewall_filtering_policy_common_late ip6tables FORWARD FORWARD
 	fi
 
 	FIREHOL_NS_CURR="${oldns}"

--- a/tests/firehol/basics/empty.aud4
+++ b/tests/firehol/basics/empty.aud4
@@ -4,15 +4,15 @@
 :FORWARD DROP [0:0]
 :OUTPUT DROP [0:0]
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 COMMIT
 #

--- a/tests/firehol/basics/empty.aud6
+++ b/tests/firehol/basics/empty.aud6
@@ -4,15 +4,15 @@
 :FORWARD DROP [0:0]
 :OUTPUT DROP [0:0]
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 COMMIT
 #

--- a/tests/firehol/basics/interface.aud4
+++ b/tests/firehol/basics/interface.aud4
@@ -32,7 +32,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -43,7 +43,7 @@
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -o eth0 -j out_myeth0
@@ -65,7 +65,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -75,7 +75,7 @@
 -A in_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
--A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
+-A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
 -A in_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth1 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -85,7 +85,7 @@
 -A in_myeth1 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth1:"
 -A in_myeth1 -m conntrack --ctstate INVALID -j DROP
--A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth1:"
+-A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-myeth1:"
 -A in_myeth1 -j DROP
 -A in_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth2 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -95,7 +95,7 @@
 -A in_myeth2 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth2:"
 -A in_myeth2 -m conntrack --ctstate INVALID -j DROP
--A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth2:"
+-A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-myeth2:"
 -A in_myeth2 -j DROP
 -A in_myeth3 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth3 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -105,7 +105,7 @@
 -A in_myeth3 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth3 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth3:"
 -A in_myeth3 -m conntrack --ctstate INVALID -j DROP
--A in_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth3:"
+-A in_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-myeth3:"
 -A in_myeth3 -j DROP
 -A in_myeth4 -s 10.0.0.0/8 -j RETURN
 -A in_myeth4 -s 169.254.0.0/16 -j RETURN
@@ -121,7 +121,7 @@
 -A in_myeth4 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth4 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth4:"
 -A in_myeth4 -m conntrack --ctstate INVALID -j DROP
--A in_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth4:"
+-A in_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-myeth4:"
 -A in_myeth4 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -132,7 +132,7 @@
 -A out_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
--A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
+-A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP
 -A out_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth1 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -143,7 +143,7 @@
 -A out_myeth1 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth1:"
 -A out_myeth1 -m conntrack --ctstate INVALID -j DROP
--A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth1:"
+-A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-myeth1:"
 -A out_myeth1 -j DROP
 -A out_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth2 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -154,7 +154,7 @@
 -A out_myeth2 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth2:"
 -A out_myeth2 -m conntrack --ctstate INVALID -j DROP
--A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth2:"
+-A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-myeth2:"
 -A out_myeth2 -j DROP
 -A out_myeth3 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth3 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -165,7 +165,7 @@
 -A out_myeth3 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth3 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth3:"
 -A out_myeth3 -m conntrack --ctstate INVALID -j DROP
--A out_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth3:"
+-A out_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-myeth3:"
 -A out_myeth3 -j DROP
 -A out_myeth4 -d 10.0.0.0/8 -j RETURN
 -A out_myeth4 -d 169.254.0.0/16 -j RETURN
@@ -182,7 +182,7 @@
 -A out_myeth4 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth4 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth4:"
 -A out_myeth4 -m conntrack --ctstate INVALID -j DROP
--A out_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth4:"
+-A out_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-myeth4:"
 -A out_myeth4 -j DROP
 COMMIT
 #

--- a/tests/firehol/basics/interface.aud6
+++ b/tests/firehol/basics/interface.aud6
@@ -27,7 +27,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -37,7 +37,7 @@
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -o eth0 -j out_myeth0
@@ -54,7 +54,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -63,7 +63,7 @@
 -A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
--A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
+-A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
 -A in_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth1 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -72,7 +72,7 @@
 -A in_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth1:"
 -A in_myeth1 -m conntrack --ctstate INVALID -j DROP
--A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth1:"
+-A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-myeth1:"
 -A in_myeth1 -j DROP
 -A in_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth2 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -81,7 +81,7 @@
 -A in_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth2:"
 -A in_myeth2 -m conntrack --ctstate INVALID -j DROP
--A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth2:"
+-A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-myeth2:"
 -A in_myeth2 -j DROP
 -A in_myeth3 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth3 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -90,7 +90,7 @@
 -A in_myeth3 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth3 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth3:"
 -A in_myeth3 -m conntrack --ctstate INVALID -j DROP
--A in_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth3:"
+-A in_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-myeth3:"
 -A in_myeth3 -j DROP
 -A in_myeth4 -s fc00::/7 -j RETURN
 -A in_myeth4 -s fe80::/10 -j RETURN
@@ -101,7 +101,7 @@
 -A in_myeth4 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth4 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth4:"
 -A in_myeth4 -m conntrack --ctstate INVALID -j DROP
--A in_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth4:"
+-A in_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-myeth4:"
 -A in_myeth4 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -111,7 +111,7 @@
 -A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
--A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
+-A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP
 -A out_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth1 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -121,7 +121,7 @@
 -A out_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth1:"
 -A out_myeth1 -m conntrack --ctstate INVALID -j DROP
--A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth1:"
+-A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-myeth1:"
 -A out_myeth1 -j DROP
 -A out_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth2 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -131,7 +131,7 @@
 -A out_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth2:"
 -A out_myeth2 -m conntrack --ctstate INVALID -j DROP
--A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth2:"
+-A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-myeth2:"
 -A out_myeth2 -j DROP
 -A out_myeth3 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth3 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -141,7 +141,7 @@
 -A out_myeth3 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth3 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth3:"
 -A out_myeth3 -m conntrack --ctstate INVALID -j DROP
--A out_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth3:"
+-A out_myeth3 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-myeth3:"
 -A out_myeth3 -j DROP
 -A out_myeth4 -d fc00::/7 -j RETURN
 -A out_myeth4 -d fe80::/10 -j RETURN
@@ -153,7 +153,7 @@
 -A out_myeth4 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth4 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth4:"
 -A out_myeth4 -m conntrack --ctstate INVALID -j DROP
--A out_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth4:"
+-A out_myeth4 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-myeth4:"
 -A out_myeth4 -j DROP
 COMMIT
 #

--- a/tests/firehol/basics/interface46.aud4
+++ b/tests/firehol/basics/interface46.aud4
@@ -21,7 +21,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -32,7 +32,7 @@
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -o eth0 -j out_myeth0
@@ -47,7 +47,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -57,7 +57,7 @@
 -A in_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
--A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
+-A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
 -A in_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth1 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -67,7 +67,7 @@
 -A in_myeth1 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth1:"
 -A in_myeth1 -m conntrack --ctstate INVALID -j DROP
--A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth1:"
+-A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-myeth1:"
 -A in_myeth1 -j DROP
 -A in_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth2 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -77,7 +77,7 @@
 -A in_myeth2 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth2:"
 -A in_myeth2 -m conntrack --ctstate INVALID -j DROP
--A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth2:"
+-A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-myeth2:"
 -A in_myeth2 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -88,7 +88,7 @@
 -A out_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
--A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
+-A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP
 -A out_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth1 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -99,7 +99,7 @@
 -A out_myeth1 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth1:"
 -A out_myeth1 -m conntrack --ctstate INVALID -j DROP
--A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth1:"
+-A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-myeth1:"
 -A out_myeth1 -j DROP
 -A out_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth2 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -110,7 +110,7 @@
 -A out_myeth2 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth2:"
 -A out_myeth2 -m conntrack --ctstate INVALID -j DROP
--A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth2:"
+-A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-myeth2:"
 -A out_myeth2 -j DROP
 COMMIT
 #

--- a/tests/firehol/basics/interface46.aud6
+++ b/tests/firehol/basics/interface46.aud6
@@ -20,7 +20,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -30,7 +30,7 @@
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -o eth1 -j out_myeth0
@@ -44,7 +44,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -53,7 +53,7 @@
 -A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
--A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
+-A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
 -A in_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth1 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -62,7 +62,7 @@
 -A in_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth1:"
 -A in_myeth1 -m conntrack --ctstate INVALID -j DROP
--A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth1:"
+-A in_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-myeth1:"
 -A in_myeth1 -j DROP
 -A in_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth2 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -71,7 +71,7 @@
 -A in_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth2:"
 -A in_myeth2 -m conntrack --ctstate INVALID -j DROP
--A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth2:"
+-A in_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-myeth2:"
 -A in_myeth2 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -81,7 +81,7 @@
 -A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
--A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
+-A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP
 -A out_myeth1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth1 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -91,7 +91,7 @@
 -A out_myeth1 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth1 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth1:"
 -A out_myeth1 -m conntrack --ctstate INVALID -j DROP
--A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth1:"
+-A out_myeth1 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-myeth1:"
 -A out_myeth1 -j DROP
 -A out_myeth2 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth2 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -101,7 +101,7 @@
 -A out_myeth2 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth2 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth2:"
 -A out_myeth2 -m conntrack --ctstate INVALID -j DROP
--A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth2:"
+-A out_myeth2 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-myeth2:"
 -A out_myeth2 -j DROP
 COMMIT
 #

--- a/tests/firehol/basics/router.aud4
+++ b/tests/firehol/basics/router.aud4
@@ -16,7 +16,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -47,7 +47,7 @@
 -A FORWARD -j out_routerb
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -59,7 +59,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_routera -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_routera -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT

--- a/tests/firehol/basics/router.aud6
+++ b/tests/firehol/basics/router.aud6
@@ -15,7 +15,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -63,7 +63,7 @@
 -A FORWARD -j out_routerb
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -74,7 +74,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_routera -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_routera -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT

--- a/tests/firehol/basics/router46.aud4
+++ b/tests/firehol/basics/router46.aud4
@@ -14,7 +14,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -27,7 +27,7 @@
 -A FORWARD ! -s 12.0.0.0/8 -d 10.0.0.0/8 -j out_myrouter
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -39,7 +39,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myrouter -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myrouter -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT

--- a/tests/firehol/basics/router46.aud6
+++ b/tests/firehol/basics/router46.aud6
@@ -13,7 +13,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -25,7 +25,7 @@
 -A FORWARD ! -s fe80:bbbb::/64 -d fe80::/64 -j out_myrouter
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -36,7 +36,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myrouter -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myrouter -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT

--- a/tests/firehol/not-both/ipv4-disable-conf.aud6
+++ b/tests/firehol/not-both/ipv4-disable-conf.aud6
@@ -14,7 +14,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -24,7 +24,7 @@
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -o eth0 -j out_myeth0
@@ -36,7 +36,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -45,7 +45,7 @@
 -A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
--A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
+-A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -55,7 +55,7 @@
 -A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
--A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
+-A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP
 COMMIT
 #

--- a/tests/firehol/not-both/ipv4-disable-defaults.aud6
+++ b/tests/firehol/not-both/ipv4-disable-defaults.aud6
@@ -14,7 +14,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -24,7 +24,7 @@
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -o eth0 -j out_myeth0
@@ -36,7 +36,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -45,7 +45,7 @@
 -A in_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
--A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
+-A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -55,7 +55,7 @@
 -A out_myeth0 -p tcp -m tcp --tcp-flags RST RST -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
--A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
+-A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP
 COMMIT
 #

--- a/tests/firehol/not-both/ipv6-disable-conf.aud4
+++ b/tests/firehol/not-both/ipv6-disable-conf.aud4
@@ -15,7 +15,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -26,7 +26,7 @@
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -o eth0 -j out_myeth0
@@ -39,7 +39,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -49,7 +49,7 @@
 -A in_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
--A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
+-A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -60,7 +60,7 @@
 -A out_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
--A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
+-A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP
 COMMIT
 #

--- a/tests/firehol/not-both/ipv6-disable-defaults.aud4
+++ b/tests/firehol/not-both/ipv6-disable-defaults.aud4
@@ -15,7 +15,7 @@
 -A INPUT -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID INPUT:"
 -A INPUT -m conntrack --ctstate INVALID -j DROP
 -A INPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
--A INPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-unknown:"
+-A INPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-unknown:"
 -A INPUT -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
 -A FORWARD -p tcp -m tcp --tcp-flags RST,ACK RST,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -26,7 +26,7 @@
 -A FORWARD -m conntrack --ctstate INVALID -j DROP
 -A FORWARD -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A FORWARD -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED PASS-unknown:"
+-A FORWARD -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED PASS-unknown:"
 -A FORWARD -j DROP
 -A OUTPUT -o lo -j ACCEPT
 -A OUTPUT -o eth0 -j out_myeth0
@@ -39,7 +39,7 @@
 -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 -A OUTPUT -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A OUTPUT -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
--A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-unknown:"
+-A OUTPUT -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-unknown:"
 -A OUTPUT -j DROP
 -A in_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A in_myeth0 -p tcp -m tcp --tcp-flags FIN,ACK FIN,ACK -m conntrack --ctstate INVALID,NEW -j DROP
@@ -49,7 +49,7 @@
 -A in_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A in_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID in_myeth0:"
 -A in_myeth0 -m conntrack --ctstate INVALID -j DROP
--A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED IN-myeth0:"
+-A in_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED IN-myeth0:"
 -A in_myeth0 -j DROP
 -A out_myeth0 -p icmp -m conntrack --ctstate RELATED -j ACCEPT
 -A out_myeth0 -p tcp -m conntrack --ctstate RELATED -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG RST,ACK -j ACCEPT
@@ -60,7 +60,7 @@
 -A out_myeth0 -p icmp -m icmp --icmp-type 3 -m conntrack --ctstate INVALID,NEW -j DROP
 -A out_myeth0 -m conntrack --ctstate INVALID -m limit --limit 1/sec -j LOG --log-prefix "DROP INVALID out_myeth0:"
 -A out_myeth0 -m conntrack --ctstate INVALID -j DROP
--A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "UNMATCHED OUT-myeth0:"
+-A out_myeth0 -m limit --limit 1/sec -j LOG --log-prefix "DROP UNMATCHED OUT-myeth0:"
 -A out_myeth0 -j DROP
 COMMIT
 #


### PR DESCRIPTION
The a router is set to policy reject, the RST packets are not sent back to the clients. They are dropped at OUTPUT interface.

This PR adds option:

```sh
FIREHOL_ACCEPT_OUTPUT_UNMATCHED_TCP_RST=0
```

When set to 1, the firewall will allow all OUTPUT TCP packets with RST in them.
