### PR TITLE
update-ipsets: detect the need to reprocess an ipset

### DIFF
--- a/sbin/update-ipsets
+++ b/sbin/update-ipsets
@@ -2881,7 +2881,7 @@ update() {
 
 		if [ \( -z "${IPSET_FILE[${ipset}]}" -o ! -f "${IPSET_FILE[${ipset}]}" -o ! -s "${BASE_DIR}/${dst}" \) -a -s  "${BASE_DIR}/${src}" ]
 			then
-			ipset_silent "${ipset}" "forced reprocessing due to incocistency in files"
+			ipset_silent "${ipset}" "forced reprocessing due to incocistency in files IPSET_FILE='${IPSET_FILE[${ipset}]}', src='${BASE_DIR}/${src}', dst='${BASE_DIR}/${dst}'"
 
 		elif [ $ret -eq ${DOWNLOAD_FAILED} ]
 			then

--- a/sbin/update-ipsets
+++ b/sbin/update-ipsets
@@ -2879,7 +2879,7 @@ update() {
 		download_manager "${ipset}" "${mins}" "${url}"
 		ret=$?
 
-		if [ \( -z "${IPSET_FILE[${ipset}]}" -o ! -f -z "${IPSET_FILE[${ipset}]}" -o ! -s "${BASE_DIR}/${dst}" \) -a -s  "${BASE_DIR}/${src}" ]
+		if [ \( -z "${IPSET_FILE[${ipset}]}" -o ! -f "${IPSET_FILE[${ipset}]}" -o ! -s "${BASE_DIR}/${dst}" \) -a -s  "${BASE_DIR}/${src}" ]
 			then
 			ipset_silent "${ipset}" "forced reprocessing due to incocistency in files"
 

--- a/sbin/update-ipsets
+++ b/sbin/update-ipsets
@@ -2879,7 +2879,7 @@ update() {
 		download_manager "${ipset}" "${mins}" "${url}"
 		ret=$?
 
-		if [ \( -z "${IPSET_FILE[${ipset}]}" -o ! -f "${IPSET_FILE[${ipset}]}" -o ! -s "${BASE_DIR}/${dst}" \) -a -s  "${BASE_DIR}/${src}" ]
+		if [ \( -z "${IPSET_FILE[${ipset}]}" -o ! -s "${BASE_DIR}/${dst}" \) -a -s  "${BASE_DIR}/${src}" ]
 			then
 			ipset_silent "${ipset}" "forced reprocessing due to incocistency in files IPSET_FILE='${IPSET_FILE[${ipset}]}', src='${BASE_DIR}/${src}', dst='${BASE_DIR}/${dst}'"
 

--- a/sbin/update-ipsets
+++ b/sbin/update-ipsets
@@ -2879,9 +2879,9 @@ update() {
 		download_manager "${ipset}" "${mins}" "${url}"
 		ret=$?
 
-		if [ \( -z "${IPSET_FILE[${ipset}]}" -o ! -s "${BASE_DIR}/${dst}" \) -a -s  "${BASE_DIR}/${src}" ]
+		if [ \( -z "${IPSET_FILE[${ipset}]}" -o ! -f "${BASE_DIR}/${dst}" \) -a -s  "${BASE_DIR}/${src}" ]
 			then
-			ipset_silent "${ipset}" "forced reprocessing due to incocistency in files IPSET_FILE='${IPSET_FILE[${ipset}]}', src='${BASE_DIR}/${src}', dst='${BASE_DIR}/${dst}'"
+			ipset_silent "${ipset}" "forced reprocessing (ignoring download status)"
 
 		elif [ $ret -eq ${DOWNLOAD_FAILED} ]
 			then

--- a/sbin/update-ipsets
+++ b/sbin/update-ipsets
@@ -2878,7 +2878,12 @@ update() {
 		# download it
 		download_manager "${ipset}" "${mins}" "${url}"
 		ret=$?
-		if [ $ret -eq ${DOWNLOAD_FAILED} ]
+
+		if [ \( -z "${IPSET_FILE[${ipset}]}" -o ! -f -z "${IPSET_FILE[${ipset}]}" -o ! -s "${BASE_DIR}/${dst}" \) -a -s  "${BASE_DIR}/${src}" ]
+			then
+			ipset_silent "${ipset}" "forced reprocessing due to incocistency in files"
+
+		elif [ $ret -eq ${DOWNLOAD_FAILED} ]
 			then
 			ipset_silent "${ipset}" "download manager reports failure"
 			check_file_too_old "${ipset}" "${BASE_DIR}/${dst}"


### PR DESCRIPTION
There was a condition that affects merged ipsets: if for any reason, the `.cache` file that update-ipsets saves in `/etc/firehol/ipsets` gets deleted or corrupted, merged ipsets fail to detect the presence of ipsets and produce merged ipsets with missing ingredients.

This PR attempts to detect this, and force reprocessing of the ipsets that somehow got lost from the `.cache` file.