### PR TITLE
firehol: don't drop icmpv6 rules with FIREHOL_RULESET_MODE optimal

### DIFF
--- a/sbin/firehol
+++ b/sbin/firehol
@@ -8028,7 +8028,7 @@ rule() {
 	# In FIREHOL_RULESET_MODE="optimal" (given as the parameter optimal=1) to us,
 	# we just create the state=NEW rules.
 	# We will work normaly though if a helper is required.
-	if [ ${optimal} -eq 1 -a "${table}" = "filter" -a -z "${helper[*]}" ]
+	if [ ${optimal} -eq 1 -a "${table}" = "filter" -a -z "${helper[*]}" -a "${proto[0]}" != "icmpv6" ]
 	then
 		if [[ "${state}" =~ 'NEW' ]]
 		then


### PR DESCRIPTION
ICMPv6 packets are stateless and necessary for basic interoperability.
If rules around them are dropped (as is the current behavior with
optimal mode), then assigned IPv6 addresses expire and eventually IPv6
connectivity is lost altogether.

Fixes: #372
Signed-off-by: Steven Noonan <steven@uplinklabs.net>