### PR TITLE
blacklist: reject with tcp-reset for outbound TCP connections

### DIFF
--- a/sbin/firehol
+++ b/sbin/firehol
@@ -4559,6 +4559,7 @@ blacklist() {
 		if running_ipv4
 		then
 			push_namespace ipv4
+			rule table filter chain "${chain}.out" out "${logopts_out_arg[@]}" proto tcp action REJECT with tcp-reset
 			rule table filter chain "${chain}.out" out "${logopts_out_arg[@]}" action REJECT with icmp-host-unreachable
 			pop_namespace
 		fi
@@ -4566,6 +4567,7 @@ blacklist() {
 		if running_ipv6
 		then
 			push_namespace ipv6
+			rule table filter chain "${chain}.out" out "${logopts_out_arg[@]}" proto tcp action REJECT with tcp-reset
 			rule table filter chain "${chain}.out" out "${logopts_out_arg[@]}" action REJECT with icmp6-addr-unreachable
 			pop_namespace
 		fi


### PR DESCRIPTION
I noticed that outbound TCP connections to blacklisted hosts were timing out rather than being rejected, I've added a `REJECT with tcp-reset` rule for outbound blacklists, which solved my problem.

---

Before using the `blacklist` directives, I had rules like this (my DNS blacklisting mechanism resolves to bogus hosts in these two IP ranges):
```
interface4 any if_blackhole
        policy return
        client all reject dst "192.0.2.0/24"
interface6 any if6_blackhole
        policy return
        client all reject dst "100::/8"
...
router4 rt_blackhole dst "192.0.2.0/24"
        route all reject
router6 rt6_blackhole dst "100::/8"
        route all reject
```

With the patch in this pull request, I can reduce it to this, and have identical behavior (TCP resets + ICMP host unreachable for everything else):
```
ipset4 create blackhole_dns4 hash:net
ipset4 add blackhole_dns4 192.0.2.0/24

ipset6 create blackhole_dns6 hash:net
ipset6 add blackhole_dns6 100::/8

blacklist4 stateful nolog ipset:blackhole_dns4
blacklist6 stateful nolog ipset:blackhole_dns6
```

Which apparently results in 26 fewer firewall rules, and is likely faster.