### PR TITLE
firehol.service: Use `firehol start` for  ExecReload=

### DIFF
--- a/contrib/firehol.service
+++ b/contrib/firehol.service
@@ -18,6 +18,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/sbin/firehol start
 ExecStop=/usr/sbin/firehol stop
+ExecReload=/usr/sbin/firehol start
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
As the title goes.

With this patch I can just run `systemctl reload firehol` to reload the config, which only runs `firehol start` without having to stop the firewall first.