### PR TITLE
Typo fix "bellow" to "below" in example fireqos-multiple-organizations.conf

### DIFF
--- a/examples/fireqos-multiple-organizations.conf
+++ b/examples/fireqos-multiple-organizations.conf
@@ -68,7 +68,7 @@ interface $DEVICE orgs bidirectional $LINKTYPE balanced input rate $INPUT_SPEED 
 	#    organization 1 is using IPs 10.0.1.0/24
 	#    organization 2 is using IPs 10.0.2.0/24
 	#    organization 3 is using IPs 10.0.3.0/24
-	# You can change these bellow, to match your setup.
+	# You can change these below, to match your setup.
 	
 	# ----------------------------------------------
 	# Organization 1


### PR DESCRIPTION
Typo fix "bellow" to "below"