### PR TITLE
workaround for cases where "-ifb" name gets truncated

### DIFF
--- a/sbin/fireqos
+++ b/sbin/fireqos
@@ -1336,8 +1336,7 @@ interface() {
 	then
 		ifb_interfaces=$((ifb_interfaces + 1))
 
-		interface_realdev=${interface_dev}-ifb
-		interface_realdev=${interface_realdev:0:15}
+		interface_realdev=${interface_dev:0:11}-ifb
 
 		runcmd $IP_CMD link add dev ${interface_realdev} name ${interface_realdev} type ifb 2>/dev/null
 		if [ $? -ne 0 -a $? -ne 2 ]


### PR DESCRIPTION
Partial fix for #351 .

This will fail if there are multiple USB interfaces with very similar MAC addresses, but at the moment _none_ of them would work at all.