### PR TITLE
update-ipsets: fix NiX Spam URL

### DIFF
--- a/sbin/update-ipsets
+++ b/sbin/update-ipsets
@@ -5861,7 +5861,7 @@ update talosintel_ipfilter 15 0 ipv4 ip \
 # http://www.heise.de/ix/NiX-Spam-DNSBL-and-blacklist-for-download-499637.html
 
 update nixspam 15 0 ipv4 ip \
-	"http://www.dnsbl.manitu.net/download/nixspam-ip.dump.gz" \
+	"https://www.nixspam.net/download/nixspam-ip.dump.gz" \
 	gz_second_word \
 	"spam" \
 	"[NiX Spam](http://www.heise.de/ix/NiX-Spam-DNSBL-and-blacklist-for-download-499637.html) IP addresses that sent spam in the last hour - automatically generated entries without distinguishing open proxies from relays, dialup gateways, and so on. All IPs are removed after 12 hours if there is no spam from there." \


### PR DESCRIPTION
According to https://iplists.firehol.org/?ipset=nixspam the last successful update was in september.

```
# curl -I http://www.dnsbl.manitu.net/download/nixspam-ip.dump.gz
HTTP/1.1 301 Moved Permanently
Date: Fri, 25 Mar 2022 18:20:52 GMT
Server: Apache
Location: https://www.nixspam.net/?old_domain=true
Content-Type: text/html; charset=iso-8859-1

# curl -I https://www.nixspam.net/download/nixspam-ip.dump.gz
HTTP/1.1 200 OK
Date: Fri, 25 Mar 2022 18:20:47 GMT
Server: Apache
Last-Modified: Fri, 25 Mar 2022 18:15:01 GMT
ETag: "212a1-5db0ef0ed09f2"
Accept-Ranges: bytes
Content-Length: 135841
Content-Type: application/x-gzip
```