### PR TITLE
Add DB-IP.com Lite as 5th geolocation source

### DIFF
--- a/html/ipsets/index.html
+++ b/html/ipsets/index.html
@@ -395,8 +395,9 @@
 				Each time an ipset is updated we check it against
 				the <a href="http://dev.maxmind.com/geoip/geoip2/geolite2/">MaxMind GeoLite2 country</a>,
 				the <a href="http://www.ipdeny.com/">IPDeny.com country</a>,
-				the <a href="http://www.ip2location.com/">IP2Location.com Lite country</a>
-				and the <a href="http://ipip.net/">IPIP.net country</a>
+				the <a href="http://www.ip2location.com/">IP2Location.com Lite country</a>,
+				the <a href="http://ipip.net/">IPIP.net country</a>
+				and the <a href="https://db-ip.com/">DB-IP.com Lite country</a>
 				databases, to find the list's unique IPs per country.
 				</p>
 				<p>
@@ -422,6 +423,7 @@
 					<li role="presentation"><a href="#ipdeny" aria-controls="ipdeny" role="tab" data-toggle="tab">IPDeny.com</a></li>
 					<li role="presentation"><a href="#ip2location" aria-controls="ip2location" role="tab" data-toggle="tab">IP2Location.com Lite</a></li>
 					<li role="presentation"><a href="#ipip" aria-controls="ipip" role="tab" data-toggle="tab">IPIP.net</a></li>
+					<li role="presentation"><a href="#dbip" aria-controls="dbip" role="tab" data-toggle="tab">DB-IP.com Lite</a></li>
 				</ul>
 				</p>
 				<div class="tab-content">
@@ -451,7 +453,14 @@
 						<tr><td height="50">&nbsp;</td>
 						</tr><tr><td align="center" valign="bottom" height="100"><span style="font-size:50px; color:#AA5555;" class="glyphicon glyphicon-refresh" aria-hidden="true"></span></td></tr>
 						<tr><td height="100" align="center" valign="top"><b>Loading ipip map...</b><br/>&nbsp;<br/>&nbsp;</td></tr>
-						<tr><td height="100">&nbsp;</td></tr></table>						
+						<tr><td height="100">&nbsp;</td></tr></table>
+					</div>
+					<div role="tabpanel" class="tab-pane" id="dbip" style="height: 450px;">
+						<table width="100%" height="350px">
+						<tr><td height="50">&nbsp;</td>
+						</tr><tr><td align="center" valign="bottom" height="100"><span style="font-size:50px; color:#AA5555;" class="glyphicon glyphicon-refresh" aria-hidden="true"></span></td></tr>
+						<tr><td height="100" align="center" valign="top"><b>Loading dbip map...</b><br/>&nbsp;<br/>&nbsp;</td></tr>
+						<tr><td height="100">&nbsp;</td></tr></table>
 					</div>
 				</div>
 			</div>
@@ -1511,6 +1520,9 @@ $(function () {
 		if(!ipset_data.ipip)
 			$('#ipip').html(charterror('<code>' + ipset + '</code> has not been compared, or does not overlap, with country data'));
 
+		if(!ipset_data.dbip)
+			$('#dbip').html(charterror('<code>' + ipset + '</code> has not been compared, or does not overlap, with country data'));
+
 		drawretention(ipset, '#age_chart', '#retention_chart');
 
 		if(data.comparison) {
@@ -1713,6 +1725,7 @@ $(function () {
 	var ipdeny_rendered = 0;
 	var ip2location_rendered = 0;
 	var ipip_rendered = 0;
+	var dbip_rendered = 0;
 	$('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
 		if(ipset && ipset_data && ipset_data.ipdeny && !ipdeny_rendered && $(e.target).attr('aria-controls') == "ipdeny") {
 			drawmap(ipset, $(e.target).attr('aria-controls'), '#' + $(e.target).attr('aria-controls'));
@@ -1725,6 +1738,10 @@ $(function () {
 		else if(ipset && ipset_data && ipset_data.ipip && !ipip_rendered && $(e.target).attr('aria-controls') == "ipip") {
 			drawmap(ipset, $(e.target).attr('aria-controls'), '#' + $(e.target).attr('aria-controls'));
 			ipip_rendered = 1;
+		}
+		else if(ipset && ipset_data && ipset_data.dbip && !dbip_rendered && $(e.target).attr('aria-controls') == "dbip") {
+			drawmap(ipset, $(e.target).attr('aria-controls'), '#' + $(e.target).attr('aria-controls'));
+			dbip_rendered = 1;
 		}
 		return(false);
 	});

--- a/sbin/update-ipsets
+++ b/sbin/update-ipsets
@@ -1536,12 +1536,13 @@ ipset_normalize_for_json() {
 }
 
 ipset_json() {
-	local ipset="${1}" geolite2="" ipdeny="" ip2location="" ipip="" comparison="" info=""
+	local ipset="${1}" geolite2="" ipdeny="" ip2location="" ipip="" dbip="" comparison="" info=""
 
 	[ -f "${RUN_DIR}/${ipset}_geolite2_country.json"    ] && geolite2="${ipset}_geolite2_country.json"
 	[ -f "${RUN_DIR}/${ipset}_ipdeny_country.json"      ] && ipdeny="${ipset}_ipdeny_country.json"
 	[ -f "${RUN_DIR}/${ipset}_ip2location_country.json" ] && ip2location="${ipset}_ip2location_country.json"
 	[ -f "${RUN_DIR}/${ipset}_ipip_country.json"        ] && ipip="${ipset}_ipip_country.json"
+	[ -f "${RUN_DIR}/${ipset}_dbip_country.json"        ] && dbip="${ipset}_dbip_country.json"
 	[ -f "${RUN_DIR}/${ipset}_comparison.json"          ] && comparison="${ipset}_comparison.json"
 
 	info="${IPSET_INFO[${ipset}]}"
@@ -1589,6 +1590,7 @@ ipset_json() {
 	"ipdeny": "${ipdeny}",
 	"ip2location": "${ip2location}",
 	"ipip": "${ipip}",
+	"dbip": "${dbip}",
 	"comparison": "${comparison}",
 	"file_local": "${file_local}",
 	"commit_history": "${commit_history}",
@@ -2097,7 +2099,7 @@ update_web() {
 		return 1
 	fi
 
-	local all=() updated=() geolite2_country=() ipdeny_country=() ip2location_country=() ipip_country=() \
+	local all=() updated=() geolite2_country=() ipdeny_country=() ip2location_country=() ipip_country=() dbip_country=() \
 		x="" i="" to_all="" all_count=0 \
 		sitemap_date="$($DATE_CMD -I)"
 
@@ -2206,6 +2208,17 @@ update_web() {
 				*)							      i="" ;;
 			esac
 			[ ! -z "${i}" ] && ipip_country=("${ipip_country[@]}" "${IPSET_FILE[$x]}" "as" "${i^^}")
+
+		elif [[ "${IPSET_FILE[$x]}" =~ ^dbip_country.* ]]
+			then
+			ipset_verbose "${x}" "is a DB-IP file"
+			to_all=0
+			case "${x}" in
+				dbip_country_*)				i=${x/dbip_country_/} ;;
+				dbip_continent_*)			i="" ;;
+				*)							i="" ;;
+			esac
+			[ ! -z "${i}" ] && dbip_country=("${dbip_country[@]}" "${IPSET_FILE[$x]}" "as" "${i^^}")
 		fi
 
 		if [ ${to_all} -eq 1 ]
@@ -2388,6 +2401,34 @@ update_web() {
 			done
 		echo >&2
 		for x in $($FIND_CMD "${RUN_DIR}" -name \*_ipip_country.json)
+		do
+			printf "\n]\n" >>${x}
+		done
+	fi
+
+	if [ "${#updated[*]}" -ne 0 -a "${#dbip_country[*]}" -ne 0 ]
+		then
+		print_ipset_reset
+
+		echo >&2 "-------------------------------------------------------------------------------"
+		echo >&2 "Comparing updated ipsets with DB-IP country..."
+
+		${IPRANGE_CMD} "${updated[@]}" --compare-next "${dbip_country[@]}" |\
+			${GREP_CMD} -v ",0$" |\
+			$SORT_CMD |\
+			while IFS="," read name1 name2 entries1 entries2 ips1 ips2 combined common
+			do
+				if [ ! -f "${RUN_DIR}/${name1}_dbip_country.json" ]
+					then
+					printf "[\n" >"${RUN_DIR}/${name1}_dbip_country.json"
+				else
+					printf ",\n" >>"${RUN_DIR}/${name1}_dbip_country.json"
+				fi
+
+				printf "	{\n		\"code\": \"${name2}\",\n		\"value\": ${common}\n	}" >>"${RUN_DIR}/${name1}_dbip_country.json"
+			done
+		echo >&2
+		for x in $($FIND_CMD "${RUN_DIR}" -name \*_dbip_country.json)
 		do
 			printf "\n]\n" >>${x}
 		done
@@ -3164,7 +3205,7 @@ rename_ipset() {
 
 	if [ -d "${WEB_DIR}" ]
 		then
-		for x in _comparison.json _geolite2_country.json _ipdeny_country.json _ip2location_country.json _ipip_country.json _history.csv retention.json .json .html
+		for x in _comparison.json _geolite2_country.json _ipdeny_country.json _ip2location_country.json _ipip_country.json _dbip_country.json _history.csv retention.json .json .html
 		do
 			if [ -f "${WEB_DIR}/${old}${x}" -a ! -f "${WEB_DIR}/${new}${x}" ]
 				then
@@ -3268,7 +3309,7 @@ delete_ipset() {
 
 	if [ -d "${WEB_DIR}" ]
 		then
-		for x in _comparison.json _geolite2_country.json _ipdeny_country.json _ip2location_country.json _ipip_country.json _history.csv retention.json .json .html
+		for x in _comparison.json _geolite2_country.json _ipdeny_country.json _ip2location_country.json _ipip_country.json _dbip_country.json _history.csv retention.json .json .html
 		do
 			if [ -f "${WEB_DIR}/${ipset}${x}" ]
 				then
@@ -4493,6 +4534,174 @@ ipip_country() {
 	return 0
 }
 
+declare -A DBIP_COUNTRY_NAMES=()
+declare -A DBIP_COUNTRY_CONTINENTS='([aq]="aq" [gs]="eu" [um]="na" [fk]="sa" [ax]="eu" [as]="oc" [ge]="as" [ar]="sa" [gd]="na" [dm]="na" [kp]="as" [rw]="af" [gg]="eu" [qa]="as" [ni]="na" [do]="na" [gf]="sa" [ru]="eu" [kr]="as" [aw]="na" [ga]="af" [rs]="eu" [no]="eu" [nl]="eu" [au]="oc" [kw]="as" [dj]="af" [at]="eu" [gb]="eu" [dk]="eu" [ky]="na" [gm]="af" [ug]="af" [gl]="na" [de]="eu" [nc]="oc" [az]="as" [hr]="eu" [na]="af" [gn]="af" [kz]="as" [et]="af" [ht]="na" [es]="eu" [gi]="eu" [nf]="oc" [ng]="af" [gh]="af" [hu]="eu" [er]="af" [ua]="eu" [ne]="af" [yt]="af" [gu]="oc" [nz]="oc" [om]="as" [gt]="na" [gw]="af" [hk]="as" [re]="af" [ag]="na" [gq]="af" [ke]="af" [gp]="na" [uz]="as" [af]="as" [hn]="na" [uy]="sa" [dz]="af" [kg]="as" [ae]="as" [ad]="eu" [gr]="eu" [ki]="oc" [nr]="oc" [eg]="af" [kh]="as" [ro]="eu" [ai]="na" [np]="as" [ee]="eu" [us]="na" [ec]="sa" [gy]="sa" [ao]="af" [km]="af" [am]="as" [ye]="as" [nu]="oc" [kn]="na" [al]="eu" [si]="eu" [fr]="eu" [bf]="af" [mw]="af" [cy]="eu" [vc]="na" [mv]="as" [bg]="eu" [pr]="na" [sk]="eu" [bd]="as" [mu]="af" [ps]="as" [va]="eu" [cz]="eu" [be]="eu" [mt]="eu" [zm]="af" [ms]="na" [bb]="na" [sm]="eu" [pt]="eu" [io]="as" [vg]="na" [sl]="af" [mr]="af" [la]="as" [in]="as" [ws]="oc" [mq]="na" [im]="eu" [lb]="as" [tz]="af" [so]="af" [mp]="oc" [ve]="sa" [lc]="na" [ba]="eu" [sn]="af" [pw]="oc" [il]="as" [tt]="na" [bn]="as" [sa]="as" [bo]="sa" [py]="sa" [bl]="na" [tv]="oc" [sc]="af" [vi]="na" [cr]="na" [bm]="na" [sb]="oc" [tw]="as" [cu]="na" [se]="eu" [bj]="af" [vn]="as" [li]="eu" [mz]="af" [sd]="af" [cw]="na" [ie]="eu" [sg]="as" [jp]="as" [my]="as" [tr]="as" [bh]="as" [mx]="na" [cv]="af" [id]="as" [lk]="as" [za]="af" [bi]="af" [ci]="af" [tl]="oc" [mg]="af" [lt]="eu" [sy]="as" [sx]="na" [pa]="na" [mf]="na" [lu]="eu" [ch]="eu" [tm]="as" [bw]="af" [jo]="as" [me]="eu" [tn]="af" [ck]="oc" [bt]="as" [lv]="eu" [wf]="oc" [to]="oc" [jm]="na" [sz]="af" [md]="eu" [br]="sa" [mc]="eu" [cm]="af" [th]="as" [pe]="sa" [cl]="sa" [bs]="na" [pf]="oc" [co]="sa" [ma]="af" [lr]="af" [tj]="as" [bq]="na" [tk]="oc" [vu]="oc" [pg]="oc" [cn]="as" [ls]="af" [ca]="na" [is]="eu" [td]="af" [fj]="oc" [mo]="as" [ph]="as" [mn]="as" [zw]="af" [ir]="as" [ss]="af" [mm]="as" [iq]="as" [sr]="sa" [je]="eu" [ml]="af" [tg]="af" [pk]="as" [fi]="eu" [bz]="na" [pl]="eu" [mk]="eu" [pm]="na" [fo]="eu" [st]="af" [ly]="af" [cd]="af" [cg]="af" [sv]="na" [tc]="na" [it]="eu" [fm]="oc" [mh]="oc" [by]="eu" [cf]="af" [xk]="eu" [cx]="as" )'
+declare -A DBIP_COUNTRIES=()
+declare -A DBIP_CONTINENTS=()
+dbip_country() {
+	cd "${RUN_DIR}" || return 1
+
+	local ipset="dbip_country" limit="" hash="net" ipv="ipv4" \
+		mins=$[24 * 60 * 30] history_mins=0 \
+		url="https://download.db-ip.com/free/dbip-country-lite-$($DATE_CMD +%Y-%m).csv.gz" \
+		info="[DB-IP](https://db-ip.com/) IP to Country Lite database" \
+		ret=
+
+	ipset_shall_be_run "${ipset}"
+	case "$?" in
+		0)	;;
+
+		1)	[ -d "${BASE_DIR}/.git" ] && echo >"${BASE_DIR}/${ipset}.setinfo" "${ipset}|${info}|${ipv} hash:${hash}|disabled|`if [ ! -z "${url}" ]; then echo "updated every $(mins_to_text ${mins}) from [this link](${url})"; fi`"
+			return 1
+			;;
+
+		*)	return 1
+			;;
+	esac
+
+	# download it
+	download_manager "${ipset}" "${mins}" "${url}"
+	ret=$?
+	if [ $ret -eq ${DOWNLOAD_FAILED} -o $ret -eq ${DOWNLOAD_NOT_UPDATED} ]
+		then
+		[ ! -s "${BASE_DIR}/${ipset}.source" ] && return 1
+		[ -d "${BASE_DIR}/${ipset}" -a ${REPROCESS_ALL} -eq 0 ] && return 1
+	fi
+
+	# create a temp dir
+	[ -d "${ipset}.tmp" ] && $RM_CMD -rf "${ipset}.tmp"
+	$MKDIR_CMD "${ipset}.tmp" || return 1
+	cd "${ipset}.tmp" || return 1
+
+	# create the final dir
+	if [ ! -d "${BASE_DIR}/${ipset}" ]
+	then
+		$MKDIR_CMD "${BASE_DIR}/${ipset}" || return 1
+	fi
+
+	# get the old version of README-EDIT.md, if any
+	if [ -d "${BASE_DIR}/.git" -a ! -f "${BASE_DIR}/${ipset}/README-EDIT.md" ]
+		then
+		$GIT_CMD -C "${BASE_DIR}" checkout ${ipset}/README-EDIT.md >/dev/null 2>&1
+		if [ ! -f ${ipset}/README-EDIT.md ]
+			then
+			$TOUCH_CMD ${ipset}/README-EDIT.md
+			git_add_if_not_already_added ${ipset}/README-EDIT.md
+		fi
+	fi
+
+	# decompress and find all the countries in the file
+	# DB-IP format: ip_start,ip_end,country_code (no quotes, gzipped CSV)
+	ipset_info "${ipset}" "finding included countries..."
+	$ZCAT_CMD <"${BASE_DIR}/${ipset}.source" |\
+		$CUT_CMD -d ',' -f 3 |\
+		$SORT_CMD -u |\
+		trim >countries
+
+	local x="" code="" name=""
+	while read x
+	do
+		[ -z "${x}" ] && continue
+
+		code="${x,,}"
+		name="${DBIP_COUNTRY_NAMES[${code}]}"
+		[ -z "${name}" ] && name="${code}"
+
+		if [ "a${code}" = "azz" ]
+			then
+			name="IPs that do not belong to any country"
+			code="countryless"
+		fi
+
+		DBIP_COUNTRY_NAMES[${code}]="${name}"
+	done <countries
+
+	ipset_info "${ipset}" "extracting countries..."
+	# reset and re-read to extract per-country data
+	for x in "${!DBIP_COUNTRY_NAMES[@]}"
+	do
+		if [ "a${x}" = "acountryless" ]
+			then
+			code="countryless"
+			name="IPs that do not belong to any country"
+
+			ipset_verbose "${ipset}" "extracting country 'ZZ' (code='${code}', name='${name}')..."
+			$ZCAT_CMD <"${BASE_DIR}/${ipset}.source" |\
+				$GREP_CMD ",ZZ$" |\
+				$CUT_CMD -d ',' -f 1,2 |\
+				$SED_CMD 's/,/ - /' |\
+				${IPRANGE_CMD} |\
+				filter_invalid4 >"dbip_country_${code}.source.tmp"
+		else
+			code="${x}"
+			name="${DBIP_COUNTRY_NAMES[${x}]}"
+
+			ipset_verbose "${ipset}" "extracting country '${x}' (code='${code}', name='${name}')..."
+			$ZCAT_CMD <"${BASE_DIR}/${ipset}.source" |\
+				$GREP_CMD ",${code^^}$" |\
+				$CUT_CMD -d ',' -f 1,2 |\
+				$SED_CMD 's/,/ - /' |\
+				${IPRANGE_CMD} |\
+				filter_invalid4 >"dbip_country_${code}.source.tmp"
+		fi
+
+		if [ ! -z "${DBIP_COUNTRY_CONTINENTS[${code}]}" ]
+			then
+			[ ! -f "dbip_continent_${DBIP_COUNTRY_CONTINENTS[${code}]}.source.tmp.info" ] && printf "%s" "Continent ${DBIP_COUNTRY_CONTINENTS[${code}]}, with countries: " >"dbip_continent_${DBIP_COUNTRY_CONTINENTS[${code}]}.source.tmp.info"
+			printf "%s" "${DBIP_COUNTRY_NAMES[${x}]} (${code^^}), " >>"dbip_continent_${DBIP_COUNTRY_CONTINENTS[${code}]}.source.tmp.info"
+			$CAT_CMD "dbip_country_${code}.source.tmp" >>"dbip_continent_${DBIP_COUNTRY_CONTINENTS[${code}]}.source.tmp"
+			DBIP_CONTINENTS[${DBIP_COUNTRY_CONTINENTS[${code}]}]="1"
+		else
+			[ ! "${code}" = "countryless" ] && ipset_warning "${ipset}" "I don't know the continent of country '${x}' (code='${code}')."
+		fi
+
+		printf "%s" "${DBIP_COUNTRY_NAMES[${x}]} (${code^^})" >"dbip_country_${code}.source.tmp.info"
+	done
+
+	ipset_info "${ipset}" "aggregating country and continent netsets..."
+	local i info tmp
+	for x in *.source.tmp
+	do
+		i=${x/.source.tmp/}
+		tmp="${i}.source"
+		local info2="$($CAT_CMD "${x}.info") -- ${info}"
+
+		$MV_CMD "${x}" "${tmp}"
+		$TOUCH_CMD -r "${BASE_DIR}/${ipset}.source" "${tmp}"
+
+		finalize "${i}" \
+			"${tmp}" \
+			"${ipset}.source" \
+			"${ipset}/${i}.netset" \
+			"${mins}" \
+			"${history_mins}" \
+			"${ipv}" \
+			"${limit}" \
+			"${hash}" \
+			"${url}" \
+			"geolocation" \
+			"${info2}" \
+			"DB-IP.com" \
+			"https://db-ip.com/" \
+			service "geolocation"
+
+		[ -f "${BASE_DIR}/${i}.setinfo" ] && $MV_CMD -f "${BASE_DIR}/${i}.setinfo" "${BASE_DIR}/${ipset}/${i}.setinfo"
+
+	done
+
+	if [ -d "${BASE_DIR}/.git" ]
+	then
+		# generate a setinfo for the home page
+		echo >"${BASE_DIR}/${ipset}.setinfo" "[${ipset}](${GITHUB_SETINFO}dbip_country)|[DB-IP.com](https://db-ip.com/) geolocation database|ipv4 hash:net|All the world|updated every `mins_to_text ${mins}` from [this link](${url})"
+	fi
+
+	# remove the temporary dir
+	cd "${RUN_DIR}"
+	$RM_CMD -rf ${ipset}.tmp
+
+	return 0
+}
+
 #eSentire() {
 #	local base="https://raw.githubusercontent.com/eSentire/malfeed/master"
 #
@@ -4705,6 +4914,12 @@ ip2location_country
 # ipip.net
 
 ipip_country
+
+
+# -----------------------------------------------------------------------------
+# DB-IP.com
+
+dbip_country
 
 
 # -----------------------------------------------------------------------------

--- a/sbin/update-ipsets
+++ b/sbin/update-ipsets
@@ -4590,11 +4590,14 @@ dbip_country() {
 		fi
 	fi
 
-	# decompress and find all the countries in the file
+	# decompress once — the file has ~600K lines, decompressing per-country would be wasteful
 	# DB-IP format: ip_start,ip_end,country_code (no quotes, gzipped CSV)
+	ipset_info "${ipset}" "decompressing database..."
+	local csvfile="dbip-data.csv"
+	$ZCAT_CMD <"${BASE_DIR}/${ipset}.source" >"${csvfile}"
+
 	ipset_info "${ipset}" "finding included countries..."
-	$ZCAT_CMD <"${BASE_DIR}/${ipset}.source" |\
-		$CUT_CMD -d ',' -f 3 |\
+	$CUT_CMD -d ',' -f 3 <"${csvfile}" |\
 		$SORT_CMD -u |\
 		trim >countries
 
@@ -4617,7 +4620,6 @@ dbip_country() {
 	done <countries
 
 	ipset_info "${ipset}" "extracting countries..."
-	# reset and re-read to extract per-country data
 	for x in "${!DBIP_COUNTRY_NAMES[@]}"
 	do
 		if [ "a${x}" = "acountryless" ]
@@ -4626,8 +4628,7 @@ dbip_country() {
 			name="IPs that do not belong to any country"
 
 			ipset_verbose "${ipset}" "extracting country 'ZZ' (code='${code}', name='${name}')..."
-			$ZCAT_CMD <"${BASE_DIR}/${ipset}.source" |\
-				$GREP_CMD ",ZZ$" |\
+			$GREP_CMD ",ZZ$" "${csvfile}" |\
 				$CUT_CMD -d ',' -f 1,2 |\
 				$SED_CMD 's/,/ - /' |\
 				${IPRANGE_CMD} |\
@@ -4637,8 +4638,7 @@ dbip_country() {
 			name="${DBIP_COUNTRY_NAMES[${x}]}"
 
 			ipset_verbose "${ipset}" "extracting country '${x}' (code='${code}', name='${name}')..."
-			$ZCAT_CMD <"${BASE_DIR}/${ipset}.source" |\
-				$GREP_CMD ",${code^^}$" |\
+			$GREP_CMD ",${code^^}$" "${csvfile}" |\
 				$CUT_CMD -d ',' -f 1,2 |\
 				$SED_CMD 's/,/ - /' |\
 				${IPRANGE_CMD} |\


### PR DESCRIPTION
## Summary

- Add `dbip_country()` function to `update-ipsets` that downloads and processes the [DB-IP Country Lite](https://db-ip.com/) free database (gzipped CSV, monthly updates)
- Generates per-country and per-continent netset files, following the same patterns as the existing 4 geo providers (GeoLite2, IPDeny, IP2Location, IPIP)
- Update the website with a new "DB-IP.com Lite" tab in the country map section
- Add `dbip` field to JSON output and geo comparison logic

## Details

DB-IP provides a free IP-to-country database updated monthly. The CSV format is `ip_start,ip_end,country_code` (no quotes, gzipped). IP ranges are converted to CIDRs via `iprange`. The `ZZ` country code (unassigned IPs) is mapped to "countryless", matching the ip2location pattern for `-` codes.

## Test plan

- [x] Verified the download URL works: `https://download.db-ip.com/free/dbip-country-lite-YYYY-MM.csv.gz`
- [x] Built and installed from source locally
- [x] Ran `update-ipsets --enable-all --reprocess run dbip_country` successfully
- [x] Verified 257 output files (7 continents + ~250 countries) in `~/ipsets/dbip_country/`
- [x] Verified netset headers and content (e.g., US has 151,781 subnets)
- [ ] Deploy to d1 after merge and verify end-to-end with website