### PR TITLE
Add ThreatFox IOC IPs feed (32K+ malware C2 IPs)

### DIFF
--- a/html/ipsets/Makefile.am
+++ b/html/ipsets/Makefile.am
@@ -33,6 +33,7 @@ ipsetsweb_DATA = \
 	maltrail_scanners.html \
 	packetmail.html \
 	spamhaus_drop.html \
+	threatfox_ioc_ips.html \
 	spamhaus_edrop.html \
 	typeahead.css
 

--- a/html/ipsets/threatfox_ioc_ips.html
+++ b/html/ipsets/threatfox_ioc_ips.html
@@ -1,0 +1,8 @@
+
+<p><a href="https://threatfox.abuse.ch/" target="_blank">ThreatFox</a> is a platform by <a href="https://abuse.ch/" target="_blank">abuse.ch</a> that collects and shares Indicators of Compromise (IOCs) associated with malware.</p>
+
+<p>This feed contains IP addresses extracted from the ThreatFox IOC database. It covers 50+ malware families including CobaltStrike, Havoc, Sliver, DCRat, XWorm, RedLine Stealer, Remcos, AsyncRAT, QuasarRAT, Metasploit, and many more modern C2 frameworks and malware strains.</p>
+
+<p>The IP list is compiled and published hourly by <a href="https://github.com/elliotwutingfeng/ThreatFox-IOC-IPs" target="_blank">elliotwutingfeng</a> from the ThreatFox API. Licensed under CC0 (public domain).</p>
+
+<p>See also: <a href="?ipset=feodo">feodo</a> (Feodo Tracker C2 IPs) and <a href="?ipset=c2_tracker">c2_tracker</a> (C2 framework tracking via Shodan/Censys).</p>

--- a/sbin/update-ipsets
+++ b/sbin/update-ipsets
@@ -5375,6 +5375,19 @@ update feodo_badips 30 0 ipv4 ip \
 
 
 # -----------------------------------------------------------------------------
+# ThreatFox by abuse.ch
+# https://threatfox.abuse.ch/
+# IP addresses from ThreatFox IOC database, compiled by elliotwutingfeng
+
+update threatfox_ioc_ips 60 0 ipv4 ip \
+	"https://raw.githubusercontent.com/elliotwutingfeng/ThreatFox-IOC-IPs/main/ips.txt" \
+	remove_comments \
+	"malware" \
+	"[ThreatFox](https://threatfox.abuse.ch/) by Abuse.ch IP addresses associated with malware C2 infrastructure including CobaltStrike, Havoc, Sliver, DCRat, XWorm, RedLine Stealer, Remcos and 50+ other malware families. Compiled by [elliotwutingfeng](https://github.com/elliotwutingfeng/ThreatFox-IOC-IPs), updated hourly." \
+	"Abuse.ch" "https://threatfox.abuse.ch/"
+
+
+# -----------------------------------------------------------------------------
 # ransomwaretracker.abuse.ch
 # by abuse.ch
 


### PR DESCRIPTION
## Summary
- Adds [ThreatFox](https://threatfox.abuse.ch/) IOC IP feed — 32K+ IPs from 50+ malware families
- Covers CobaltStrike, Havoc, Sliver, DCRat, XWorm, RedLine Stealer, Remcos, AsyncRAT, and more
- Compiled hourly from abuse.ch ThreatFox API by [elliotwutingfeng](https://github.com/elliotwutingfeng/ThreatFox-IOC-IPs)
- CC0 licensed (public domain, redistributable)
- Fills gap left by empty sslbl (0 IPs) and near-empty feodo (5 IPs) feeds

## Test plan
- [x] Tested locally: 32,342 unique IPs parsed successfully
- [x] Output format verified (header, IP count, structure)